### PR TITLE
Adds the next size tier (4 vCPU / 8 GB) of Hetzner Cloud instances to the benchmark suite.

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -42,3 +42,33 @@ providers:
         pricing:
           hourly_eur: 0.0100
           monthly_eur: 7.19
+
+      - id: cx32
+        name: "CX32"
+        arch: "Intel"
+        vcpu: 4
+        ram_gb: 8
+        disk_gb: 80
+        pricing:
+          hourly_eur: 0.0100
+          monthly_eur: 7.19
+
+      - id: cax21
+        name: "CAX21"
+        arch: "ARM64"
+        vcpu: 4
+        ram_gb: 8
+        disk_gb: 80
+        pricing:
+          hourly_eur: 0.0110
+          monthly_eur: 7.90
+
+      - id: cpx32
+        name: "CPX32"
+        arch: "AMD EPYC"
+        vcpu: 4
+        ram_gb: 8
+        disk_gb: 160
+        pricing:
+          hourly_eur: 0.0180
+          monthly_eur: 12.90


### PR DESCRIPTION
Changes
  - Added `CX32` — Intel x86, 4 vCPU, 8 GB RAM, 80 GB disk
  - Added `CAX21` — ARM64, 4 vCPU, 8 GB RAM, 80 GB disk
  - Added `CPX32` — AMD EPYC, 4 vCPU, 8 GB RAM, 160 GB disk