### PR TITLE
UI fixes: header spacing, chart labels, mobile responsiveness + deploy-ui workflow

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,68 @@
+name: Deploy UI
+
+on:
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: "22.14.0"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Find latest successful benchmark run
+        id: find_run
+        run: |
+          RUN_ID=$(gh run list \
+            --workflow=benchmark.yml \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error::No successful benchmark run found"
+            exit 1
+          fi
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          echo "Using benchmark data from run $RUN_ID"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download benchmark data
+        run: |
+          gh run download ${{ steps.find_run.outputs.run_id }} \
+            --name benchmark-processed \
+            --dir frontend/public/data/
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '${{ env.NODE_VERSION }}'
+
+      - name: Build Frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: frontend/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/frontend/src/components/ComparisonCharts.jsx
+++ b/frontend/src/components/ComparisonCharts.jsx
@@ -100,22 +100,22 @@ function ComparisonCharts({ charts }) {
   if (!charts) return null
 
   return (
-    <div className="card">
+    <div className="card" style={{ overflow: 'hidden' }}>
       <h2 className="card-title">Performance Charts</h2>
       <div className="grid grid-3" style={{ marginTop: '1rem' }}>
-        <div style={{ height: '220px' }}>
+        <div className="chart-cell" style={{ height: '220px' }}>
           <canvas ref={singleRef}></canvas>
         </div>
-        <div style={{ height: '220px' }}>
+        <div className="chart-cell" style={{ height: '220px' }}>
           <canvas ref={multiRef}></canvas>
         </div>
-        <div style={{ height: '220px' }}>
+        <div className="chart-cell" style={{ height: '220px' }}>
           <canvas ref={memoryRef}></canvas>
         </div>
-        <div style={{ height: '220px' }}>
+        <div className="chart-cell" style={{ height: '220px' }}>
           <canvas ref={diskRef}></canvas>
         </div>
-        <div className="chart-wide" style={{ height: '220px' }}>
+        <div className="chart-cell chart-wide" style={{ height: '220px' }}>
           <canvas ref={valueRef}></canvas>
         </div>
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -73,8 +73,8 @@ a:hover {
   position: relative;
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
-  padding: 1rem 1.5rem;
-  margin: 0 -1.5rem 1.5rem;
+  padding: 1rem 2rem;
+  margin: 0 0 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -198,6 +198,16 @@ a:hover {
   }
 }
 
+@media (max-width: 900px) {
+  .grid-3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .chart-wide {
+    grid-column: span 2;
+  }
+}
+
 @media (max-width: 768px) {
   .grid-2, .grid-3, .grid-4 {
     grid-template-columns: 1fr;
@@ -210,6 +220,12 @@ a:hover {
 
 .chart-wide {
   grid-column: span 2;
+}
+
+.chart-cell {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Stat Card - Dense data display */

--- a/scripts/process_results.py
+++ b/scripts/process_results.py
@@ -16,6 +16,16 @@ import pandas as pd
 SCHEMA_VERSION = "2.0"
 
 
+def normalize_arch(arch: str) -> str:
+    """Normalize architecture to X86 or ARM64."""
+    if not arch:
+        return "X86"
+    lower = arch.lower()
+    if "arm" in lower or "aarch" in lower:
+        return "ARM64"
+    return "X86"
+
+
 def load_config(config_path: str) -> dict:
     with open(config_path, "r") as f:
         return yaml.safe_load(f)
@@ -157,7 +167,7 @@ def normalize_results(
             {
                 "instance_key": key,
                 "instance_type": inst_type.upper(),
-                "display_name": f"{inst_type.upper()} ({inst_config.get('arch', 'Unknown')})",
+                "display_name": f"{inst_type.upper()} ({normalize_arch(inst_config.get('arch', ''))})",
                 "vcpu": inst_config.get("vcpu", attrs.get("vcpu", 0)),
                 "ram_gb": inst_config.get("ram_gb", 0),
                 "disk_gb": inst_config.get("disk_gb", 0),
@@ -291,7 +301,7 @@ def generate_summary_data(df: pd.DataFrame, provider: str, region: str) -> dict:
         return {}
 
     df_sorted = df.sort_values("overall_score", ascending=False)
-    labels = df_sorted["display_name"].tolist()
+    labels = df_sorted["instance_type"].tolist()
 
     return {
         "schema_version": SCHEMA_VERSION,


### PR DESCRIPTION
Summary                                                                                       
  - Header content was flush against the viewport edge (negative margin cancelled all padding);
  fixed with proper spacing                                                                        
  - Performance charts showed raw "Intel / AMD EPYC / Intel (Dedicated)" arch strings instead of
  X86/ARM64; fixed in both the data pipeline and chart label rendering
  - Performance charts overflowed the screen on mobile; fixed with proper CSS containment and an
  intermediate 900px breakpoint
  - New "Deploy UI" workflow allows redeploying the frontend without re-running benchmarks (fetches
   latest benchmark artifact automatically)