### PR TITLE
fix: clean arch/pricing data model and chart responsive layout

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -1,5 +1,6 @@
 providers:
   hetzner:
+    currency: EUR
     regions:
       nbg1:
         name: Nuremberg
@@ -14,22 +15,22 @@ providers:
     instances:
     - id: cx23
       name: CX23
-      arch: Intel
+      arch: X86
       vcpu: 2
       ram_gb: 4
       disk_gb: 40
       pricing:
-        hourly_eur: 0.00576
-        monthly_eur: 3.588
+        hourly: 0.00576
+        monthly: 3.588
     - id: cx33
       name: CX33
-      arch: Intel
+      arch: X86
       vcpu: 4
       ram_gb: 8
       disk_gb: 80
       pricing:
-        hourly_eur: 0.0096
-        monthly_eur: 5.988
+        hourly: 0.0096
+        monthly: 5.988
     - id: cax11
       name: CAX11
       arch: ARM64
@@ -37,8 +38,8 @@ providers:
       ram_gb: 4
       disk_gb: 40
       pricing:
-        hourly_eur: 0.00636
-        monthly_eur: 3.948
+        hourly: 0.00636
+        monthly: 3.948
     - id: cax21
       name: CAX21
       arch: ARM64
@@ -46,44 +47,44 @@ providers:
       ram_gb: 8
       disk_gb: 80
       pricing:
-        hourly_eur: 0.01152
-        monthly_eur: 7.188
+        hourly: 0.01152
+        monthly: 7.188
     - id: cpx22
       name: CPX22
-      arch: AMD EPYC
+      arch: X86
       vcpu: 2
       ram_gb: 4
       disk_gb: 80
       pricing:
-        hourly_eur: 0.01152
-        monthly_eur: 7.188
+        hourly: 0.01152
+        monthly: 7.188
     - id: cpx32
       name: CPX32
-      arch: AMD EPYC
+      arch: X86
       vcpu: 4
       ram_gb: 8
       disk_gb: 160
       pricing:
-        hourly_eur: 0.02016
-        monthly_eur: 12.588
+        hourly: 0.02016
+        monthly: 12.588
     - id: ccx13
       name: CCX13
-      arch: Intel (Dedicated)
+      arch: X86
       vcpu: 2
       ram_gb: 8
       disk_gb: 80
       pricing:
-        hourly_eur: 0.02508
-        monthly_eur: 15.588
+        hourly: 0.02508
+        monthly: 15.588
     - id: ccx23
       name: CCX23
-      arch: Intel (Dedicated)
+      arch: X86
       vcpu: 4
       ram_gb: 16
       disk_gb: 160
       pricing:
-        hourly_eur: 0.05004
-        monthly_eur: 31.188
+        hourly: 0.05004
+        monthly: 31.188
 _metadata:
   last_pricing_update: '2026-02-23T16:23:59.169879'
   source: Hetzner Cloud API

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,13 +29,6 @@ const DataAPI = {
   }
 }
 
-function normalizeArch(raw) {
-  if (!raw) return 'X86'
-  const lower = raw.toLowerCase()
-  if (lower.includes('arm') || lower.includes('aarch')) return 'ARM64'
-  return 'X86'
-}
-
 function parseExprFilter(expr, value) {
   if (!expr || expr.trim() === '') return true
   const match = expr.trim().match(/^([<>]=?|=)?\s*(\d+\.?\d*)$/)
@@ -67,7 +60,7 @@ function transformData(data) {
     ranking: instances.map(inst => ({
       instance_type: inst.id,
       display_name: inst.name,
-      arch: normalizeArch(inst.specs?.arch),
+      arch: inst.specs?.arch || 'X86',
       vcpu: inst.specs?.vcpu || 0,
       ram_gb: inst.specs?.ram_gb || 0,
       disk_gb: inst.specs?.disk_gb || 0,
@@ -222,12 +215,6 @@ function App() {
       .map((r, i) => filteredTypes.has(r.instance_type) ? i : -1)
       .filter(i => i !== -1)
 
-    const archMap = Object.fromEntries(
-      filteredRanking.map(r => [r.instance_type, r.arch])
-    )
-
-    const fmtLabel = (type, arch) => `${type.toUpperCase()} (${arch})`
-
     const sortByValue = (labels, values) => {
       const pairs = labels.map((l, i) => [l, values[i]])
       pairs.sort((a, b) => b[1] - a[1])
@@ -238,10 +225,12 @@ function App() {
     }
 
     const buildChart = (chartKey) => {
-      const rawLabels = filteredIndices.map(i => data.charts[chartKey].labels[i])
-      const rawValues = filteredIndices.map(i => data.charts[chartKey].values[i])
-      const namedLabels = rawLabels.map(type => fmtLabel(type, archMap[type] || ''))
-      return sortByValue(namedLabels, rawValues)
+      const values = filteredIndices.map(i => data.charts[chartKey].values[i])
+      const labels = filteredIndices.map(i => {
+        const inst = data.ranking[i]
+        return `${inst.instance_type} (${inst.arch})`
+      })
+      return sortByValue(labels, values)
     }
 
     return {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -8,12 +8,6 @@ function Header({ metadata }) {
       <div className="header-logo">
         Cloud<span>Bench</span>
       </div>
-      <div className="header-brand">
-        <nav className="header-nav">
-          <a href="#" className="nav-tab active">Instances</a>
-        </nav>
-      </div>
-
       <div className="header-meta">
         Generated: {generatedAt} • Median of 5 runs
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -192,6 +192,16 @@ a:hover {
   grid-template-columns: repeat(4, 1fr);
 }
 
+.chart-wide {
+  grid-column: span 2;
+}
+
+.chart-cell {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+}
+
 @media (max-width: 1200px) {
   .grid-4 {
     grid-template-columns: repeat(2, 1fr);
@@ -201,10 +211,6 @@ a:hover {
 @media (max-width: 900px) {
   .grid-3 {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  .chart-wide {
-    grid-column: span 2;
   }
 }
 
@@ -216,16 +222,6 @@ a:hover {
   .chart-wide {
     grid-column: span 1;
   }
-}
-
-.chart-wide {
-  grid-column: span 2;
-}
-
-.chart-cell {
-  position: relative;
-  min-width: 0;
-  overflow: hidden;
 }
 
 /* Stat Card - Dense data display */

--- a/scripts/estimate_cost.py
+++ b/scripts/estimate_cost.py
@@ -28,7 +28,7 @@ def estimate_cost(
     USD_RATE = 1.08
 
     total_cost_eur = sum(
-        i.get("pricing", {}).get("hourly_eur", 0) * RUNTIME_HOURS for i in to_benchmark
+        i.get("pricing", {}).get("hourly", 0) * RUNTIME_HOURS for i in to_benchmark
     )
     total_cost_usd = total_cost_eur * USD_RATE
 

--- a/scripts/process_results.py
+++ b/scripts/process_results.py
@@ -154,7 +154,7 @@ def normalize_results(
         attrs = r.get("provider_attributes", {})
         if not attrs:
             attrs = {
-                "arch": system.get("arch", inst_config.get("arch", "Unknown")),
+                "arch": system.get("arch", inst_config.get("arch", "")),
                 "os": system.get("os", "Unknown"),
                 "kernel": system.get("kernel"),
                 "vcpu": system.get("vcpu", inst_config.get("vcpu", 0)),
@@ -171,8 +171,8 @@ def normalize_results(
                 "vcpu": inst_config.get("vcpu", attrs.get("vcpu", 0)),
                 "ram_gb": inst_config.get("ram_gb", 0),
                 "disk_gb": inst_config.get("disk_gb", 0),
-                "price_hourly": pricing.get("hourly_eur", 0),
-                "price_monthly": pricing.get("monthly_eur", 0),
+                "price_hourly": pricing.get("hourly", 0),
+                "price_monthly": pricing.get("monthly", 0),
                 "metrics": {
                     "cpu_single_raw": cpu.get("single_thread_events", 0),
                     "cpu_multi_raw": cpu.get("multi_thread_events", 0),
@@ -291,12 +291,14 @@ def create_instance_summary(row: pd.Series) -> dict:
             "vcpu": row["vcpu"],
             "ram_gb": row["ram_gb"],
             "disk_gb": row["disk_gb"],
-            "arch": provider_attrs.get("arch", "Unknown"),
+            "arch": normalize_arch(provider_attrs.get("arch", "")),
         },
     }
 
 
-def generate_summary_data(df: pd.DataFrame, provider: str, region: str) -> dict:
+def generate_summary_data(
+    df: pd.DataFrame, provider: str, region: str, currency: str = "EUR"
+) -> dict:
     if df.empty:
         return {}
 
@@ -308,7 +310,7 @@ def generate_summary_data(df: pd.DataFrame, provider: str, region: str) -> dict:
         "metadata": {
             "generated_at": datetime.now().isoformat(),
             "run_count": len(df),
-            "currency": "EUR",
+            "currency": currency,
             "provider": provider,
             "region": region,
         },
@@ -328,7 +330,9 @@ def generate_summary_data(df: pd.DataFrame, provider: str, region: str) -> dict:
     }
 
 
-def generate_detail_data(df: pd.DataFrame, provider: str, region: str) -> dict:
+def generate_detail_data(
+    df: pd.DataFrame, provider: str, region: str, currency: str = "EUR"
+) -> dict:
     if df.empty:
         return {}
 
@@ -346,7 +350,7 @@ def generate_detail_data(df: pd.DataFrame, provider: str, region: str) -> dict:
         "metadata": {
             "generated_at": datetime.now().isoformat(),
             "run_count": len(df),
-            "currency": "EUR",
+            "currency": currency,
             "provider": provider,
             "region": region,
         },
@@ -456,12 +460,18 @@ def main():
 
         df = calculate_scores(df)
 
+        currency = (
+            config.get("providers", {})
+            .get(args.provider, {})
+            .get("currency", "EUR")
+        )
+
         timestamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
         summary_file = f"summary-{timestamp}.json"
         detail_file = f"detail-{timestamp}.json"
 
-        summary_data = generate_summary_data(df, args.provider, args.region)
-        detail_data = generate_detail_data(df, args.provider, args.region)
+        summary_data = generate_summary_data(df, args.provider, args.region, currency)
+        detail_data = generate_detail_data(df, args.provider, args.region, currency)
         summary_md = generate_markdown_summary(df)
 
         metadata = {

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -53,8 +53,8 @@ def parse_pricing(server_type: dict) -> Optional[dict]:
         return None
 
     return {
-        "hourly_eur": float(hourly_gross),
-        "monthly_eur": float(monthly_gross),
+        "hourly": float(hourly_gross),
+        "monthly": float(monthly_gross),
     }
 
 
@@ -63,9 +63,7 @@ def get_architecture(server_type: dict) -> str:
     name = server_type.get("name", "").lower()
     if "cax" in name:
         return "ARM64"
-    if "cpx" in name:
-        return "AMD EPYC"
-    return "Intel"
+    return "X86"
 
 
 def update_config(
@@ -95,14 +93,14 @@ def update_config(
 
         old_pricing = inst.get("pricing", {})
         if (
-            old_pricing.get("hourly_eur") != pricing["hourly_eur"]
-            or old_pricing.get("monthly_eur") != pricing["monthly_eur"]
+            old_pricing.get("hourly") != pricing["hourly"]
+            or old_pricing.get("monthly") != pricing["monthly"]
         ):
             inst["pricing"] = pricing
             updated += 1
-            print(f"  [UPDATED] {inst_id}: €{pricing['monthly_eur']}/mo")
+            print(f"  [UPDATED] {inst_id}: €{pricing['monthly']}/mo")
         else:
-            print(f"  [OK] {inst_id}: €{pricing['monthly_eur']}/mo (unchanged)")
+            print(f"  [OK] {inst_id}: €{pricing['monthly']}/mo (unchanged)")
 
     print(f"\nSummary: {updated} updated")
 

--- a/tests/test_process_results.py
+++ b/tests/test_process_results.py
@@ -144,11 +144,11 @@ class TestNormalizeResults(unittest.TestCase):
                         {
                             "id": "cx11",
                             "name": "CX11",
-                            "arch": "Intel",
+                            "arch": "X86",
                             "vcpu": 1,
                             "ram_gb": 2,
                             "disk_gb": 20,
-                            "pricing": {"hourly_eur": 0.0048, "monthly_eur": 3.49},
+                            "pricing": {"hourly": 0.0048, "monthly": 3.49},
                         }
                     ]
                 }
@@ -188,6 +188,8 @@ class TestCalculateScores(unittest.TestCase):
                     },
                     "price_hourly": 0.0048,
                     "price_monthly": 3.49,
+                    "display_name": "CX11 (X86)",
+                    "provider_attributes": {"arch": "X86"},
                 },
                 {
                     "instance_type": "CPX11",
@@ -199,6 +201,8 @@ class TestCalculateScores(unittest.TestCase):
                     },
                     "price_hourly": 0.0066,
                     "price_monthly": 4.89,
+                    "display_name": "CPX11 (X86)",
+                    "provider_attributes": {"arch": "X86"},
                 },
             ]
         )
@@ -252,7 +256,7 @@ class TestGenerateSummaryData(unittest.TestCase):
             [
                 {
                     "instance_type": "CX11",
-                    "display_name": "CX11 (Intel)",
+                    "display_name": "CX11 (X86)",
                     "vcpu": 1,
                     "ram_gb": 2,
                     "disk_gb": 20,
@@ -266,7 +270,7 @@ class TestGenerateSummaryData(unittest.TestCase):
                     "value_monthly": 150,
                     "cpu_value_monthly": 150,
                     "metrics": {},
-                    "provider_attributes": {"arch": "x86_64"},
+                    "provider_attributes": {"arch": "X86"},
                 }
             ]
         )
@@ -323,11 +327,11 @@ class TestExtensibility(unittest.TestCase):
                         {
                             "id": "t3-micro",
                             "name": "T3 Micro",
-                            "arch": "Intel",
+                            "arch": "X86",
                             "vcpu": 2,
                             "ram_gb": 1,
                             "disk_gb": 0,
-                            "pricing": {"hourly_eur": 0.0104, "monthly_eur": 7.60},
+                            "pricing": {"hourly": 0.0104, "monthly": 7.60},
                         }
                     ]
                 }


### PR DESCRIPTION
  - instances.yaml: arch values normalized to X86/ARM64, pricing keys renamed hourly_eur/monthly_eur -> hourly/monthly, currency: EUR added per provider
  - process_results.py: apply normalize_arch() in create_instance_summary(), read currency from provider config
  - update_pricing.py: output hourly/monthly keys, get_architecture() returns X86/ARM64
  - estimate_cost.py: update pricing key references
  - App.jsx: remove normalizeArch(), remove Instances nav tab, fix chart label construction
  - index.css: fix .chart-wide rule ordering so 768px collapse to single column works
  - tests: update fixtures for new arch values and pricing keys