### PR TITLE
fix: remove automatic cleanup-aws schedule

### DIFF
--- a/.github/workflows/cleanup-aws.yml
+++ b/.github/workflows/cleanup-aws.yml
@@ -1,8 +1,6 @@
 name: Cleanup AWS Orphans
 
 on:
-  schedule:
-    - cron: '0 */6 * * *'  # Every 6 hours
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Cleanup now only runs manually via workflow_dispatch. This prevents accidental cleanup during benchmarking.