### PR TITLE
fix: remove automatic update-pricing schedule

### DIFF
--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -1,8 +1,6 @@
 name: Update Pricing
 
 on:
-  schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 6 AM UTC
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Pricing updates now only run manually via workflow_dispatch. Prevents any automatic API calls to cloud providers.