### PR TITLE
Add local benchmark script, metric averaging, history table fix, docs overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ htmlcov/
 
 # Logs
 *.log
+
+# Local benchmark artifacts
+bench-*.json
+randread.*

--- a/README.md
+++ b/README.md
@@ -4,29 +4,72 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Live Results](https://img.shields.io/badge/Live%20Results-View%20Dashboard-blue)](https://fabianwimberger.github.io/cloud-bench/)
 
-A cloud instance benchmarking suite comparing CPU, memory, and disk performance across instance types and providers with cost analysis.
+A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 19 instance types across Hetzner Cloud, AWS EC2, and OVHcloud.
 
 ## Why This Project?
 
-Cloud instance pricing and performance characteristics vary significantly between providers and instance types. $20/month can get you vastly different compute capabilities depending on your choice. This project provides reproducible, data-driven benchmarks to make informed infrastructure decisions based on actual performance rather than marketing specifications.
+Cloud instance pricing and performance vary significantly between providers and instance types. $20/month can get you vastly different compute capabilities depending on your choice. This project provides reproducible, data-driven benchmarks to make informed infrastructure decisions based on actual performance rather than marketing specs.
 
 **Goals:**
 - Compare instance types objectively using standardized benchmarks
 - Factor in cost to determine real value (performance per dollar)
 - Provide reproducible results that can be independently verified
 
-## Features
+## Live Dashboard
 
-- **Multi-provider support** — Hetzner Cloud, AWS EC2, and OVHcloud
-- **Standardized benchmarks** — CPU (sysbench), Memory (sysbench), Disk I/O (fio)
-- **Cost analysis** — performance per dollar across instance types
-- **Currency support** — EUR (Hetzner, OVHcloud) and USD (AWS) with toggle in dashboard
-- **Interactive dashboard** — React-based visualization with instance history tracking
-- **Historical data** — benchmark results persisted across runs on a dedicated data branch
-- **Automated infrastructure** — Terraform for provisioning, Ansible for execution
-- **Security-first** — fresh SSH keys per run, automatic cleanup
+View the latest results at **[fabianwimberger.github.io/cloud-bench](https://fabianwimberger.github.io/cloud-bench/)**
 
-## Quick Start
+Scores shown are averaged across all benchmark runs for each instance type, not just the latest run.
+
+## Instance Types
+
+### Hetzner Cloud (8 instances, EUR)
+
+| ID | vCPU | RAM | Disk | Monthly |
+|----|------|-----|------|---------|
+| cx23 | 2 | 4 GB | 40 GB | €2.99 |
+| cx33 | 4 | 8 GB | 80 GB | €4.99 |
+| cax11 (ARM) | 2 | 4 GB | 40 GB | €3.29 |
+| cax21 (ARM) | 4 | 8 GB | 80 GB | €5.99 |
+| cpx22 | 2 | 4 GB | 80 GB | €5.99 |
+| cpx32 | 4 | 8 GB | 160 GB | €10.49 |
+| ccx13 | 2 | 8 GB | 80 GB | €12.99 |
+| ccx23 | 4 | 16 GB | 160 GB | €25.99 |
+
+### AWS EC2 (6 instances, USD, eu-central-1)
+
+| ID | vCPU | RAM | Disk | Monthly |
+|----|------|-----|------|---------|
+| t3.micro | 2 | 1 GB | 20 GB | $8.64 |
+| t3.small | 2 | 2 GB | 20 GB | $17.28 |
+| t4g.micro (ARM) | 2 | 1 GB | 20 GB | $6.91 |
+| t4g.small (ARM) | 2 | 2 GB | 20 GB | $13.82 |
+| c7i-flex.large | 2 | 4 GB | 20 GB | $69.67 |
+| m7i-flex.large | 2 | 8 GB | 20 GB | $82.59 |
+
+### OVHcloud (5 instances, EUR, DE1)
+
+| ID | vCPU | RAM | Disk | Monthly |
+|----|------|-----|------|---------|
+| d2-4 | 2 | 4 GB | 50 GB | €14.26 |
+| b3-8 | 2 | 8 GB | 50 GB | €33.48 |
+| c3-4 | 2 | 4 GB | 50 GB | €29.88 |
+| c3-8 | 4 | 8 GB | 100 GB | €59.76 |
+| r3-16 | 2 | 16 GB | 50 GB | €43.34 |
+
+## Run Benchmarks Locally
+
+Compare your own machine against the official results — no cloud credentials needed:
+
+```bash
+git clone https://github.com/fabianwimberger/cloud-bench.git
+cd cloud-bench
+sudo bash scripts/run-local-bench.sh
+```
+
+Runs the exact same sysbench/fio benchmarks and outputs a JSON file + terminal summary. See [docs/local-benchmark.md](docs/local-benchmark.md) for details.
+
+## Quick Start (Cloud Benchmarks)
 
 ```bash
 # Clone and configure
@@ -48,20 +91,22 @@ export OVH_OPENSTACK_PASSWORD="your-password"
 export OVH_CLOUD_PROJECT_ID="your-project-id"
 PROVIDER=ovhcloud ./scripts/run-local.sh
 
-# Or run via GitHub Actions: Actions → Run Benchmarks
+# Or run via GitHub Actions: Actions > Run Benchmarks
 ```
 
 ## How It Works
 
 ```
-Terraform → Ansible (sysbench/fio) → Python (scoring) → React Dashboard
+config/instances.yaml → Terraform → Ansible (sysbench/fio) → Python (scoring) → React Dashboard
 ```
 
 **Methodology:**
 - 5 runs per test, median value used for consistency
 - Scores normalized 0-100 per category
 - Weights: CPU 40%, Memory 35%, Disk 25%
+- Raw metrics averaged across all historical runs per instance
 - Cost-efficiency calculated from monthly price and composite score
+- All benchmarks run on Ubuntu 24.04 in EU (Frankfurt) regions
 
 ## Configuration
 
@@ -71,6 +116,7 @@ Edit `config/instances.yaml` to add/remove instances:
 providers:
   hetzner:
     currency: EUR
+    default_region: fsn1
     instances:
       - id: cx23
         name: CX23
@@ -79,81 +125,91 @@ providers:
         ram_gb: 4
         disk_gb: 40
         pricing:
-          hourly: 0.00576
-          monthly: 3.588
-  ovhcloud:
-    currency: EUR
-    instances:
-      - id: b3-8
-        name: B3-8
-        arch: X86
-        vcpu: 2
-        ram_gb: 8
-        disk_gb: 50
-        pricing:
-          hourly: 0.0300
-          monthly: 21.60
-  aws:
-    currency: USD
-    instances:
-      - id: t3.micro
-        name: t3.micro
-        arch: X86
-        vcpu: 2
-        ram_gb: 1
-        disk_gb: 20
-        pricing:
-          hourly: 0.012
-          monthly: 8.64
+          hourly: 0.0048
+          monthly: 2.99
 ```
+
+No code changes needed — Terraform, Ansible, and the frontend all pick up config changes automatically. See [docs/configuration.md](docs/configuration.md) for details.
 
 ## Project Structure
 
 ```
 cloud-bench/
-├── ansible/              # Benchmark playbooks
-│   └── playbooks/
-│       └── benchmark.yml
-├── config/               # Instance configurations
+├── ansible/              # Benchmark playbook + templates
+│   ├── playbooks/
+│   │   └── benchmark.yml
+│   └── templates/
+├── config/               # Instance types, specs, pricing
 │   └── instances.yaml
 ├── docs/                 # Documentation
-├── frontend/             # React dashboard
+├── frontend/             # React dashboard (Vite + Chart.js)
 │   └── src/
-├── scripts/              # Helper scripts
+│       └── components/
+├── scripts/              # Processing, pricing, utilities
 │   ├── process_results.py
+│   ├── merge_summaries.py
+│   ├── build_history.py
 │   ├── update_pricing.py
 │   ├── update_manifest.py
-│   ├── build_history.py
-│   └── run-local.sh
+│   ├── estimate_cost.py
+│   ├── validate.py
+│   ├── run-local.sh
+│   ├── run-local-bench.sh
+│   └── parse-instances.sh
 ├── terraform/            # Infrastructure provisioning
 │   └── modules/
 │       ├── hetzner/
 │       ├── aws/
 │       └── ovhcloud/
-└── tests/                # Test suite
+└── tests/
 ```
+
+## Features
+
+- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud (19 instance types)
+- **Standardized benchmarks** — CPU (sysbench), Memory (sysbench), Disk I/O (fio)
+- **Metric averaging** — scores based on all historical runs, not just the latest
+- **Cost analysis** — performance per dollar with EUR/USD toggle
+- **Interactive dashboard** — filtering, comparison, per-instance history charts
+- **Automated pricing** — live pricing from provider APIs + ECB exchange rates
+- **Security-first** — fresh SSH keys per run, firewall whitelisting, automatic cleanup
+- **Cost guards** — pre-run estimation blocks expensive configurations ($5 / 15 instance limit)
+- **Local benchmarking** — standalone script for users to compare their own hardware
 
 ## Security
 
 - Fresh Ed25519 SSH key generated per run, never reused
+- Firewall/security group allows SSH from runner IP only
 - Auto-cleanup via `if: always()` — infrastructure destroyed even if benchmarks fail
-- Cost guard — estimation before each run blocks expensive configurations
+- Orphan cleanup workflows as safety net (every 6 hours for Hetzner/AWS, manual for OVHcloud)
 
 ## Cost
 
-~10 minutes per run, costs a few cents. Infrastructure is destroyed automatically even if benchmarks fail.
+~10 minutes per run, costs a few cents. Infrastructure is destroyed automatically.
 
-**Protection:**
-- Cost estimation before each run (blocks >$5 or >15 instances)
-- Orphan cleanup every 6 hours (Hetzner and AWS)
+| Provider | Typical run cost |
+|----------|-----------------|
+| Hetzner  | ~€0.05          |
+| AWS      | ~$0.15          |
+| OVHcloud | ~€0.15          |
+
+**Protection:** Cost estimation before each run (blocks >$5 or >15 instances), billing alerts recommended.
+
+## Documentation
+
+- [Setup Guide](docs/setup-guide.md) — credentials and first run
+- [Configuration](docs/configuration.md) — instances, regions, providers
+- [Architecture](docs/architecture.md) — system design and scoring
+- [Data Format](docs/data-format.md) — JSON schemas
+- [Cost Analysis](docs/cost-analysis.md) — per-run costs and safety nets
+- [Runbook](docs/runbook.md) — troubleshooting
+- [Local Benchmark](docs/local-benchmark.md) — run benchmarks on your own machine
 
 ## License
 
 MIT License — see [LICENSE](LICENSE) file.
 
 ### Third-Party Licenses
-
-This project uses the following open-source components:
 
 | Component | License | Source |
 |-----------|---------|--------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,59 +1,106 @@
 # Architecture
 
+## Pipeline
+
 ```
-config/instances.yaml          # Single source of truth for instances & pricing
+config/instances.yaml            # Single source of truth for instances & pricing
         │
         ▼
 ┌── Terraform ──────────────┐
-│  modules/hetzner/          │  Provisions servers, SSH keys, firewalls
-│  modules/aws/              │  EC2 instances, security groups, key pairs
-│  modules/ovhcloud/         │  OpenStack instances, key pairs
+│  modules/hetzner/          │   Provisions servers, SSH keys, firewalls
+│  modules/aws/              │   EC2 instances, security groups, key pairs
+│  modules/ovhcloud/         │   OpenStack instances, key pairs (no security groups)
 └────────────┬──────────────┘
              ▼
 ┌── Ansible ────────────────┐
-│  playbooks/benchmark.yml   │  Runs sysbench (CPU, RAM) + fio (Disk)
-└────────────┬──────────────┘  5 runs each, takes median
+│  playbooks/benchmark.yml   │   Runs sysbench (CPU, RAM) + fio (Disk)
+└────────────┬──────────────┘   5 runs each, takes median
              ▼
 ┌── Python ─────────────────┐
-│  scripts/process_results.py│  Normalizes, scores, outputs JSON/CSV
-│  scripts/update_manifest.py│  Indexes runs into manifest.json
-│  scripts/build_history.py  │  Builds per-instance history.json
+│  process_results.py        │   Normalizes, scores, outputs JSON/CSV/Markdown
+│  update_manifest.py        │   Indexes run into manifest.json
+│  build_history.py          │   Builds per-instance history from all runs
+│  merge_summaries.py        │   Merges providers, averages metrics across runs
 └────────────┬──────────────┘
              ▼
 ┌── Frontend ───────────────┐
-│  React + Vite              │  Dashboard on GitHub Pages
+│  React + Vite + Chart.js   │   Dashboard on GitHub Pages
 └───────────────────────────┘
 ```
 
+## Data Persistence
+
+All benchmark data lives on the `benchmark-data` branch:
+
+```
+data/
+├── manifest.json                              # Index of all runs (schema v3.0)
+└── runs/
+    └── <timestamp>-<provider>-<region>/
+        ├── raw/                               # Raw benchmark JSON per instance
+        ├── summary.json                       # Scored summary for this run
+        └── detail.json                        # Full metrics + provider attributes
+```
+
+The deploy step merges all runs into `benchmark-data.json` and `history.json` for the frontend.
+
 ## Benchmarks
 
-| Component | Tool | Test |
-|-----------|------|------|
-| CPU | sysbench | Prime numbers to 20,000 |
-| RAM | sysbench | Sequential read/write |
-| Disk | fio | Random read IOPS |
+| Component | Tool | Command |
+|-----------|------|---------|
+| CPU (single) | sysbench | `sysbench cpu --cpu-max-prime=20000 --threads=1` |
+| CPU (multi) | sysbench | `sysbench cpu --cpu-max-prime=20000 --threads=<nproc>` |
+| Memory read | sysbench | `sysbench memory --memory-oper=read --memory-total-size=1G` |
+| Memory write | sysbench | `sysbench memory --memory-oper=write --memory-total-size=1G` |
+| Disk IOPS | fio | `fio --rw=randread --bs=4k --iodepth=32 --direct=1 --runtime=20` |
+
+All benchmarks run on Ubuntu 24.04. Each test runs 5 times, median is used.
 
 ## Scoring
 
-All scores are normalized 0-100 relative to the best performer in the run.
+Scores are normalized 0-100 relative to the best performer across all instances.
 
 ```
 CPU Score     = (Single Core + Multi Core) / 2
 Overall Score = CPU * 0.40 + Memory * 0.35 + Disk * 0.25
-Value Score   = Overall Score / Monthly Price (in provider's native currency)
+Value Score   = Overall Score / Monthly Price
 ```
 
-## Data format
+### Metric Averaging
+
+When multiple benchmark runs exist for an instance, raw metrics (CPU events, memory throughput, disk IOPS) are averaged across all runs before scoring. This reduces noise from single-run variance. Scores are then recalculated from the averaged metrics.
+
+### Cross-Provider Rescaling
+
+When merging results from multiple providers, all scores are rescaled against the global maximum so instances from different providers are directly comparable. Pricing is normalized to USD using ECB exchange rates.
+
+## Data Formats
 
 - **Summary** (~5KB): scores, pricing, specs — loads fast for the dashboard
 - **Detail**: full raw metrics + `provider_attributes` for extensibility
-- **Manifest**: index of all historical runs
+- **Manifest** (v3.0): index of all historical runs with `instance_index` for lookups
+- **History** (v3.0): pre-built per-instance time series for the history view
 
-See [data-format.md](data-format.md) for the schema.
+See [data-format.md](data-format.md) for full schemas.
 
 ## Security
 
 - Fresh Ed25519 SSH key generated per run, never reused
-- Firewall/security group allows SSH from runner IP only (key-based auth)
-- `if: always()` cleanup in CI
-- Dedicated Hetzner project, AWS IAM user, and OVHcloud OpenStack user recommended for isolation
+- Firewall/security group allows SSH from runner IP only (Hetzner + AWS)
+- OVHcloud does not support security groups — SSH key auth only
+- `if: always()` cleanup in CI ensures infrastructure destruction
+- Orphan cleanup workflows: every 6 hours (Hetzner, AWS), manual trigger (OVHcloud)
+- Dedicated project/IAM user/OpenStack user recommended for isolation
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `benchmark.yml` | Manual | Full benchmark pipeline: provision → benchmark → process → deploy |
+| `validate.yml` | Push/PR | CI: terraform, ansible, python (ruff/mypy/pytest), frontend, trivy |
+| `pr-check.yml` | PR | Terraform format, init, validate, plan |
+| `cost-guard.yml` | Called | Reusable cost estimation (blocks >$5 or >15 instances) |
+| `deploy-ui.yml` | Manual | Rebuild and deploy frontend to GitHub Pages |
+| `update-pricing.yml` | Manual | Fetch live pricing from provider APIs + ECB exchange rates |
+| `cleanup-aws.yml` | Manual | Terminate orphaned AWS instances older than 2 hours |
+| `cleanup-ovhcloud.yml` | Manual | Terminate orphaned OVHcloud instances older than 2 hours |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,8 @@
 # Configuration
 
-All instance types, specs, and pricing are defined in `config/instances.yaml`. This is the single source of truth — the rest of the project reads from it dynamically.
+All instance types, specs, and pricing are defined in `config/instances.yaml`. This is the single source of truth — Terraform, Ansible, scoring, and the frontend all read from it dynamically.
 
-## File structure
+## File Structure
 
 ```yaml
 providers:
@@ -13,7 +13,7 @@ providers:
       <region_id>:
         name: "Human Readable Name"
     instances:
-      - id: <instance_id>        # Must match the cloud provider's type ID
+      - id: <instance_id>        # Must match the cloud provider's flavor/type ID
         name: "Display Name"
         arch: X86|ARM64
         vcpu: <number>
@@ -24,57 +24,67 @@ providers:
           monthly: <price>
 
 exchange_rates:
-  usd_to_eur: 0.92               # Updated by pricing workflow
-  eur_to_usd: 1.087
-  last_updated: '2026-02-23T12:00:00'
+  eur_to_usd: 1.1555            # Updated by pricing workflow
+  usd_to_eur: 0.8654
+  last_updated: '2026-03-20'
   source: Frankfurter API (ECB data)
 ```
 
-## Adding instances
+## Current Providers
 
-Add entries to the `instances` list. No code changes needed — Terraform, Ansible, and the frontend all pick them up automatically.
+| Provider | Currency | Default Region | Instances |
+|----------|----------|---------------|-----------|
+| Hetzner  | EUR | fsn1 (Falkenstein) | 8 (cx23, cx33, cax11, cax21, cpx22, cpx32, ccx13, ccx23) |
+| AWS      | USD | eu-central-1 (Frankfurt) | 6 (t3.micro, t3.small, t4g.micro, t4g.small, c7i-flex.large, m7i-flex.large) |
+| OVHcloud | EUR | DE1 (Frankfurt) | 5 (d2-4, b3-8, c3-4, c3-8, r3-16) |
+
+## Adding Instances
+
+Add entries to the `instances` list. No code changes needed — everything picks them up automatically.
 
 ```yaml
 # Hetzner example
-- id: cx33
-  name: CX33
-  arch: X86
-  vcpu: 4
-  ram_gb: 8
-  disk_gb: 80
-  pricing:
-    hourly: 0.0096
-    monthly: 5.988
-
-# AWS example
-- id: t3.medium
-  name: t3.medium
+- id: cx23
+  name: CX23
   arch: X86
   vcpu: 2
   ram_gb: 4
-  disk_gb: 20
+  disk_gb: 40
   pricing:
-    hourly: 0.0416
-    monthly: 29.95
+    hourly: 0.0048
+    monthly: 2.99
 
-# OVHcloud example
-- id: b3-8
-  name: B3-8
+# AWS example
+- id: t3.small
+  name: t3.small
   arch: X86
   vcpu: 2
-  ram_gb: 8
+  ram_gb: 2
+  disk_gb: 20
+  pricing:
+    hourly: 0.024
+    monthly: 17.28
+
+# OVHcloud example
+- id: d2-4
+  name: D2-4
+  arch: X86
+  vcpu: 2
+  ram_gb: 4
   disk_gb: 50
   pricing:
-    hourly: 0.0300
-    monthly: 21.60
+    hourly: 0.0198
+    monthly: 14.26
 ```
 
-## Adding regions
+The `id` must match the provider's instance type/flavor name exactly (e.g. `cx23`, `t3.micro`, `d2-4`).
+
+## Adding Regions
 
 Add to the `regions` map. Use the provider's region code as the key.
 
 ```yaml
-# Hetzner
+# Hetzner (fsn1, nbg1, hel1, ash, hil)
 regions:
   fsn1:
     name: Falkenstein
@@ -90,17 +100,17 @@ regions:
     name: Frankfurt
 ```
 
-## Adding providers
+## Adding Providers
 
-1. Add the provider config to `instances.yaml` with `currency` and `default_region`
+1. Add the provider config to `instances.yaml` with `currency`, `default_region`, `regions`, and `instances`
 2. Create a Terraform module at `terraform/modules/<provider>/`
 3. Update the `cloud_provider` validation in `terraform/variables.tf`
 4. Add the provider's credentials to GitHub Secrets
-5. Add a cleanup workflow for orphaned resources (manual trigger only)
+5. Add a cleanup workflow for orphaned resources
 
-## Pricing updates
+## Pricing Updates
 
-Pricing is updated automatically by the `update-pricing` workflow, which fetches live prices from each provider's API and updates exchange rates from the ECB.
+Pricing is updated automatically by the `update-pricing` workflow, which fetches live prices from each provider's API and exchange rates from the ECB.
 
 ```bash
 # Update all providers
@@ -108,11 +118,25 @@ python scripts/update_pricing.py --provider all
 
 # Update a specific provider
 python scripts/update_pricing.py --provider aws
+
+# Dry run (no changes written)
+python scripts/update_pricing.py --provider all --dry-run
 ```
+
+APIs used:
+- **Hetzner**: `api.hetzner.cloud/v1/pricing` (public, no auth)
+- **AWS**: `api.pricing.us-east-1.amazonaws.com` (requires AWS credentials)
+- **OVHcloud**: `api.ovh.com/v1/order/catalog/public/cloud` (public, no auth)
+- **Exchange rates**: Frankfurter API (ECB data)
 
 ## Validation
 
 ```bash
+# YAML syntax
 python -c "import yaml; yaml.safe_load(open('config/instances.yaml'))"
+
+# Terraform
 cd terraform && terraform init && terraform validate
 ```
+
+The `validate.yml` CI workflow checks config validity on every push and PR.

--- a/docs/cost-analysis.md
+++ b/docs/cost-analysis.md
@@ -1,32 +1,43 @@
-# Cost
+# Cost Analysis
 
-## Per run
+## Per Run
 
-A benchmark run creates all configured instances for a single provider for ~10 minutes. This costs a few cents per run.
+A benchmark run provisions all configured instances for a single provider for ~10 minutes, then destroys them. Costs a few cents.
 
-Exact pricing depends on which instances are configured in `config/instances.yaml`.
+| Provider | Instances | Typical Cost |
+|----------|-----------|-------------|
+| Hetzner  | 8         | ~€0.05      |
+| AWS      | 6         | ~$0.15      |
+| OVHcloud | 5         | ~€0.15      |
 
-| Provider | Typical run cost | Currency |
-|----------|-----------------|----------|
-| Hetzner  | ~€0.05          | EUR      |
-| AWS      | ~$0.15          | USD      |
-| OVHcloud | ~€0.15          | EUR      |
+Exact cost depends on which instances are configured in `config/instances.yaml`. The cost-guard workflow estimates this before each run and blocks anything over $5 or 15 instances.
 
-## Worst case
+## Worst Case
 
-If cleanup fails and instances keep running, the maximum cost equals the sum of hourly prices for all configured instances. Check `config/instances.yaml` for current pricing.
+If cleanup fails and instances keep running, the maximum hourly cost is the sum of all configured hourly prices:
 
-**Safety nets:**
-- Set a billing alert in Hetzner Console (e.g. €10)
-- Set a budget alert in AWS Budgets (e.g. $10)
-- Set a budget alert in OVHcloud Control Panel (e.g. €10)
-- Orphan cleanup workflows run every 6 hours (Hetzner, AWS) or manual trigger (OVHcloud) as safety net
+| Provider | All instances hourly | All instances monthly |
+|----------|---------------------|----------------------|
+| Hetzner  | €0.1167             | €72.72               |
+| AWS      | $0.2792             | $198.91              |
+| OVHcloud | €0.2310             | €180.72              |
 
-## Provider comparison
+## Safety Nets
+
+1. **Cost guard** — pre-run estimation blocks expensive configurations
+2. **Billing alerts** — set in each provider's console (recommended: €10 / $10)
+3. **Auto-cleanup** — `if: always()` in CI destroys infrastructure even on failure
+4. **Orphan cleanup** — scheduled workflows terminate instances older than 2 hours
+   - Hetzner: every 6 hours (automated)
+   - AWS: every 6 hours (automated)
+   - OVHcloud: manual trigger
+
+## Provider Comparison
 
 | | Hetzner | AWS | OVHcloud |
 |---|---------|-----|----------|
-| Pricing model | Simple, predictable | On-demand, region-dependent | Simple, hourly/monthly |
+| Pricing | Simple, flat hourly/monthly | On-demand, region-dependent | Hourly consumption billing |
 | Hidden fees | None | Egress, EBS IOPS (minimal for benchmarks) | None |
-| Entry-level cost | ~€3.50/mo (CX23) | ~$24/mo (t4g.medium) | ~€20/mo (C3-4) |
+| Cheapest instance | €2.99/mo (CX23) | $6.91/mo (t4g.micro) | €14.26/mo (D2-4) |
 | Cleanup | hcloud CLI / scheduled workflow | AWS CLI / scheduled workflow | OpenStack CLI / manual workflow |
+| Billing granularity | Hourly | Per-second | Hourly |

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -1,76 +1,94 @@
-# Data Format (v2.0)
+# Data Format
 
-## Output files
+## Overview
+
+Benchmark data is persisted on the `benchmark-data` branch and served to the frontend as static JSON.
 
 ```
-frontend/public/data/
-├── benchmark-data.json          # Latest summary (used by dashboard)
-├── summary-YYYYMMDD-HHMMSS.json # Historical summaries
-├── detail-YYYYMMDD-HHMMSS.json  # Full historical data with raw metrics
-├── manifest.json                # Index of all runs
-├── history.json                 # Per-instance history (built from all runs)
-├── summary.md                   # Markdown summary
-└── benchmark-results.csv        # CSV export
+data/                                    # On benchmark-data branch
+├── manifest.json                        # Index of all runs (schema v3.0)
+└── runs/
+    └── <timestamp>-<provider>-<region>/
+        ├── raw/                         # Raw benchmark JSON per instance
+        ├── summary.json                 # Scored summary (schema v2.0)
+        └── detail.json                  # Full metrics (schema v2.0)
+
+frontend/public/data/                    # Built during deploy
+├── benchmark-data.json                  # Merged cross-provider view (schema v2.0)
+├── history.json                         # Per-instance history (schema v3.0)
+└── manifest.json                        # Copy of manifest
 ```
 
-## Summary format
+## Per-Run Summary (v2.0)
 
-~5KB, used by the dashboard landing page. Each run is provider-specific.
+~5KB per run. Provider-specific, used as input for merging.
 
 ```json
 {
   "schema_version": "2.0",
   "metadata": {
-    "generated_at": "2026-02-21T09:15:00Z",
-    "run_count": 3,
+    "generated_at": "2026-03-21T18:37:52Z",
+    "run_count": 5,
     "currency": "EUR",
     "provider": "hetzner",
     "region": "fsn1",
-    "exchange_rates": { "usd_to_eur": 0.92, "eur_to_usd": 1.087 }
+    "exchange_rates": { "usd_to_eur": 0.8654, "eur_to_usd": 1.1555 }
   },
   "summary": {
-    "labels": ["CPX22 (AMD EPYC)", "CAX11 (ARM64)", "CX23 (Intel)"],
+    "labels": ["CX23", "CPX22", "CAX11"],
     "instances": [
       {
-        "id": "CPX22",
-        "name": "CPX22 (AMD EPYC)",
-        "scores": { "single_core": 100, "multi_core": 100, "memory": 100, "disk": 100, "overall": 100 },
-        "pricing": { "hourly": 0.0100, "monthly": 7.19 },
-        "value": 13.91,
-        "specs": { "vcpu": 2, "ram_gb": 4, "disk_gb": 80, "arch": "AMD EPYC" }
+        "id": "CX23",
+        "name": "CX23",
+        "scores": {
+          "single_core": 21.2,
+          "multi_core": 21.0,
+          "memory": 50.3,
+          "disk": 77.9,
+          "overall": 40.5
+        },
+        "metrics": {
+          "cpu_single_events": 876.43,
+          "cpu_multi_events": 1721.55,
+          "memory_mib_per_sec": 14892.30,
+          "disk_iops": 19306.27
+        },
+        "pricing": { "hourly": 0.0048, "monthly": 2.99 },
+        "value": 13.5,
+        "specs": { "vcpu": 2, "ram_gb": 4, "disk_gb": 40, "arch": "X86" }
       }
     ],
     "charts": {
-      "single_core": [100, 77.5, 21.2],
-      "multi_core": [100, 77.4, 21.0],
-      "memory": [100, 51.1, 50.3],
-      "disk": [100, 88.1, 77.9],
-      "value": [13.91, 19.59, 5.88]
+      "single_core": [21.2, 100, 77.5],
+      "multi_core": [21.0, 100, 77.4],
+      "memory": [50.3, 100, 51.1],
+      "disk": [77.9, 100, 88.1],
+      "value": [13.5, 13.9, 19.6]
     }
   }
 }
 ```
 
-## Detail format
+## Per-Run Detail (v2.0)
 
 Full data including raw metrics and system info.
 
 ```json
 {
   "schema_version": "2.0",
-  "metadata": { "..." : "same as summary" },
+  "metadata": { "...": "same as summary" },
   "instances": [
     {
-      "id": "CPX22",
-      "scores": { "..." : "same as summary" },
-      "pricing": { "..." : "same as summary" },
-      "specs": { "..." : "same as summary" },
+      "id": "CX23",
+      "scores": { "...": "same as summary" },
+      "pricing": { "...": "same as summary" },
+      "specs": { "...": "same as summary" },
       "metrics": {
-        "cpu_single_raw": 1643.35,
-        "cpu_multi_raw": 3274.31,
-        "mem_read_raw": 17291.41,
-        "mem_write_raw": 12964.65,
-        "mem_throughput_raw": 30256.06,
+        "cpu_single_raw": 876.43,
+        "cpu_multi_raw": 1721.55,
+        "mem_read_raw": 8521.41,
+        "mem_write_raw": 6370.89,
+        "mem_throughput_raw": 14892.30,
         "disk_iops_raw": 19306.27
       },
       "provider_attributes": {
@@ -85,43 +103,88 @@ Full data including raw metrics and system info.
 }
 ```
 
-## Manifest
+## Merged Benchmark Data (v2.0)
 
-Index for browsing historical runs. Persisted on the `benchmark-data` branch.
+Cross-provider view built by `merge_summaries.py`. This is what the dashboard loads.
+
+- Raw metrics are **averaged** across all historical runs per instance
+- Scores are **rescaled** against the global maximum across all providers
+- Pricing is **normalized to USD**
 
 ```json
 {
   "schema_version": "2.0",
-  "runs": [
-    {
-      "id": "2026-02-21-091512",
-      "timestamp": "2026-02-21T09:15:12Z",
-      "provider": "hetzner",
-      "region": "fsn1",
-      "instance_count": 3,
-      "files": {
-        "summary": "summary-2026-02-21-091512.json",
-        "detail": "detail-2026-02-21-091512.json"
+  "metadata": {
+    "generated_at": "2026-03-21T19:00:00Z",
+    "run_count": 19,
+    "currency": "USD",
+    "providers": ["hetzner", "aws", "ovhcloud"],
+    "exchange_rates": { "usd_to_eur": 0.8654, "eur_to_usd": 1.1555 }
+  },
+  "summary": {
+    "labels": ["CX23", "t3.micro", "D2-4", "..."],
+    "instances": [
+      {
+        "id": "CX23",
+        "provider": "hetzner",
+        "region": "fsn1",
+        "scores": { "single_core": 21.2, "multi_core": 21.0, "memory": 50.3, "disk": 77.9, "overall": 40.5 },
+        "metrics": { "cpu_single_events": 876.43, "cpu_multi_events": 1721.55, "memory_mib_per_sec": 14892.30, "disk_iops": 19306.27 },
+        "pricing": { "hourly": 0.0055, "monthly": 3.45 },
+        "value": 11.7,
+        "specs": { "vcpu": 2, "ram_gb": 4, "disk_gb": 40, "arch": "X86" }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
-## History
+## Manifest (v3.0)
 
-Pre-built per-instance history for the dashboard's history view. Built by `scripts/build_history.py` from all runs in the manifest.
+Index of all historical runs. Persisted on the `benchmark-data` branch.
 
 ```json
 {
-  "schema_version": "2.0",
+  "schema_version": "3.0",
+  "runs": [
+    {
+      "id": "2026-03-21T18:37:52-hetzner-fsn1",
+      "timestamp": "2026-03-21T18:37:52",
+      "provider": "hetzner",
+      "region": "fsn1",
+      "instances": ["CX23", "CX33", "CAX11"],
+      "files": {
+        "summary": "data/runs/2026-03-21T18:37:52-hetzner-fsn1/summary.json",
+        "detail": "data/runs/2026-03-21T18:37:52-hetzner-fsn1/detail.json"
+      }
+    }
+  ],
+  "instance_index": {
+    "CX23": ["2026-03-21T18:37:52-hetzner-fsn1"],
+    "CX33": ["2026-03-21T18:37:52-hetzner-fsn1"]
+  }
+}
+```
+
+## History (v3.0)
+
+Pre-built per-instance history for the dashboard's history view. Built by `build_history.py`.
+
+```json
+{
+  "schema_version": "3.0",
+  "generated_at": "2026-03-21T19:00:00Z",
   "instances": {
-    "cx23": {
+    "CX23": {
+      "provider": "hetzner",
+      "specs": { "vcpu": 2, "ram_gb": 4, "arch": "X86" },
       "runs": [
         {
-          "run_id": "2026-02-21-091512",
-          "timestamp": "2026-02-21T09:15:12Z",
-          "scores": { "overall": 85.2, "single_core": 90.1, "multi_core": 80.3, "memory": 88.0, "disk": 77.5 }
+          "timestamp": "2026-03-21T17:11:43",
+          "region": "fsn1",
+          "scores": { "single_core": 21.2, "multi_core": 21.0, "memory": 50.3, "disk": 77.9, "overall": 40.5 },
+          "metrics": { "cpu_single_raw": 876.43, "cpu_multi_raw": 1721.55, "mem_throughput_raw": 14892.30, "disk_iops_raw": 19306.27 },
+          "pricing": { "hourly": 0.0048, "monthly": 2.99 }
         }
       ]
     }
@@ -131,8 +194,8 @@ Pre-built per-instance history for the dashboard's history view. Built by `scrip
 
 ## `provider_attributes`
 
-Extensible field for provider-specific data. No schema changes needed when adding new providers — just include whatever fields are relevant.
+Extensible field for provider-specific data. No schema changes needed when adding new providers — include whatever fields are relevant (architecture, OS, kernel, burstable flags, etc.).
 
 ## Currency
 
-Prices are stored in the provider's native currency (EUR for Hetzner and OVHcloud, USD for AWS). Exchange rates are included in metadata so the frontend can convert between currencies on the fly.
+Prices are stored in the provider's native currency (EUR for Hetzner/OVHcloud, USD for AWS). Exchange rates from ECB are included in metadata. The merged `benchmark-data.json` normalizes everything to USD. The frontend allows toggling between EUR and USD.

--- a/docs/local-benchmark.md
+++ b/docs/local-benchmark.md
@@ -1,0 +1,42 @@
+# Run Benchmarks Locally
+
+Run the same benchmarks used by cloud-bench on your own machine or server to get a point of reference against the [official results](https://fabianwimberger.github.io/cloud-bench/).
+
+## Quick Start
+
+```bash
+git clone https://github.com/fabianwimberger/cloud-bench.git
+cd cloud-bench
+sudo bash scripts/run-local-bench.sh
+```
+
+## Requirements
+
+- Linux with a supported package manager (apt, pacman, dnf, yum, zypper, apk)
+- Root access (for installing tools and direct disk I/O)
+- The script installs `sysbench`, `fio`, `jq`, and `bc` if not already present
+
+## What It Runs
+
+| Benchmark | Tool | Parameters |
+|-----------|------|------------|
+| CPU single-thread | sysbench | `--cpu-max-prime=20000 --threads=1` |
+| CPU multi-thread | sysbench | `--cpu-max-prime=20000 --threads=<nproc>` |
+| Memory read | sysbench | `--memory-oper=read --memory-total-size=1G` |
+| Memory write | sysbench | `--memory-oper=write --memory-total-size=1G` |
+| Disk IOPS | fio | `randread bs=4k iodepth=32 direct=1 runtime=20s` |
+
+Each benchmark runs **5 times** and the **median** is taken — identical to the official cloud-bench methodology.
+
+## Output
+
+- A JSON file (`bench-<hostname>-<date>.json`) in the current directory
+- A summary table printed to the terminal
+
+The JSON format matches the official benchmark result structure, so you can directly compare values against the results on the [dashboard](https://fabianwimberger.github.io/cloud-bench/).
+
+## Notes
+
+- Results are local only and are not uploaded anywhere.
+- Disk IOPS depends heavily on the storage type (NVMe vs SSD vs HDD) and filesystem. For a fair comparison, ensure `direct=1` I/O is supported on your setup.
+- Running on a busy system will affect results. For best accuracy, minimize other workloads during the benchmark.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,112 +1,122 @@
-# Runbook: When Things Go Wrong
+# Runbook
 
-## Quick Fixes
+## Cleanup Failed — Resources Still Running
 
-### Cleanup Failed - Resources Still Running
+**Symptom**: Workflow failed, servers still running in provider console.
 
-**Symptom**: Workflow failed, servers still show in Hetzner Console, AWS Console, or OVHcloud Horizon.
-
-**Auto-fix**: Scheduled cleanup workflows run every 6 hours (Hetzner, AWS) or manual trigger (OVHcloud) and will clean up anything older than 2 hours or tagged `cloud-bench` resources.
+**Auto-fix**: Orphan cleanup workflows run every 6 hours (Hetzner, AWS) or manual trigger (OVHcloud) and clean up anything older than 2 hours tagged `cloud-bench`.
 
 **Manual fix (Hetzner)**:
 ```bash
-# Install hcloud CLI
-brew install hcloud  # macOS
-# or download from https://github.com/hetznercloud/cli/releases
-
-# Set your token
 export HCLOUD_TOKEN="your-token"
 
 # List cloud-bench servers
 hcloud server list | grep cloud-bench
 
-# Delete specific server
-hcloud server delete <server-name>
-
-# Or delete all cloud-bench servers
-hcloud server list -o json | jq -r '.[] | select(.name | contains("cloud-bench")) | .id' | xargs -I {} hcloud server delete {}
+# Delete all cloud-bench servers
+hcloud server list -o json | jq -r '.[] | select(.name | contains("cloud-bench")) | .id' \
+  | xargs -I {} hcloud server delete {}
 ```
 
 **Manual fix (AWS)**:
 ```bash
-# Using AWS CLI
 export AWS_DEFAULT_REGION=eu-central-1
 
 # List cloud-bench instances
 aws ec2 describe-instances --filters "Name=tag:project,Values=cloud-bench" \
   --query 'Reservations[].Instances[].[InstanceId,State.Name,Tags[?Key==`Name`].Value|[0]]' --output table
 
-# Terminate specific instance
-aws ec2 terminate-instances --instance-ids <instance-id>
-
 # Terminate all cloud-bench instances
 aws ec2 describe-instances --filters "Name=tag:project,Values=cloud-bench" "Name=instance-state-name,Values=running" \
-  --query 'Reservations[].Instances[].InstanceId' --output text | xargs aws ec2 terminate-instances --instance-ids
+  --query 'Reservations[].Instances[].InstanceId' --output text \
+  | xargs aws ec2 terminate-instances --instance-ids
 ```
 
-### SSH Connection Failures
+**Manual fix (OVHcloud)**:
+```bash
+# Using OpenStack CLI
+export OS_AUTH_URL=https://auth.cloud.ovh.net/v3
+export OS_USERNAME="user-xxxxx"
+export OS_PASSWORD="your-password"
+export OS_PROJECT_ID="your-project-id"
+export OS_REGION_NAME=DE1
+
+# List cloud-bench instances
+openstack server list | grep cloud-bench
+
+# Delete all cloud-bench instances
+openstack server list -f value -c ID -c Name | grep cloud-bench | awk '{print $1}' \
+  | xargs -I {} openstack server delete {}
+```
+
+## SSH Connection Failures
 
 **Symptom**: "Failed to connect to the host via ssh"
 
-**Check**:
-1. Your IP may have changed mid-run (rare but happens)
-2. Hetzner's firewall may not have updated
-3. Instance is still booting
+**Causes**:
+1. Runner IP changed mid-run
+2. Firewall not yet updated
+3. Instance still booting (especially OVHcloud — can take longer)
 
-**Fix**: Just re-run the workflow. The IP whitelist is regenerated each run.
+**Fix**: Re-run the workflow. The IP whitelist is regenerated each run. OVHcloud does not use security groups, so SSH failures there are usually boot timing.
 
-### Terraform State Locked/Corrupted
+## Terraform State Locked/Corrupted
 
-**Symptom**: "Error acquiring the state lock" or weird plan output
+**Symptom**: "Error acquiring the state lock" or unexpected plan output
 
 **Fix**:
 ```bash
 cd terraform
 rm -f terraform.tfstate.lock.info
 terraform init
-# If state is really broken, delete it (you'll need to manually clean up resources)
+# If state is really broken, delete it (manually clean up resources first)
 rm terraform.tfstate
 ```
 
-### Cost Guard Blocked My Run
+## Cost Guard Blocked My Run
 
 **Symptom**: "Estimated cost $X exceeds limit"
 
-**Fix**: You're trying to run too many instances at once. Either:
-1. Run with fewer instances
-2. Increase `MAX_COST_USD` in `.github/workflows/cost-guard.yml` (not recommended)
-3. Use `skip_cost_guard: true` (not recommended unless you know what you're doing)
+**Fix**: You're trying to run too many or too expensive instances. Either:
+1. Run with fewer instances (use the `instances` input to select specific ones)
+2. Use `skip_cost_guard: true` in the workflow dispatch (not recommended)
 
-### Frontend Shows "Something Went Wrong"
+The default limits are $5 per run and 15 instances max.
+
+## Frontend Shows "Something Went Wrong"
 
 **Symptom**: Error boundary caught an error
 
 **Check**:
 1. Open browser console (F12) for details
-2. Check that `benchmark-data.json` exists in `frontend/public/data/`
-3. Verify JSON is valid: `cat frontend/public/data/benchmark-data.json | jq .`
+2. Verify `benchmark-data.json` exists in `frontend/public/data/`
+3. Validate JSON: `cat frontend/public/data/benchmark-data.json | jq .`
 
-**Fix**: Re-run the process job: `python scripts/process_results.py ...`
+**Fix**: Re-run the deploy step or manually run `merge_summaries.py` and `build_history.py`.
+
+## Pricing Out of Date
+
+**Symptom**: Dashboard shows old prices
+
+**Fix**: Run the pricing update workflow (Actions > Update Pricing) or manually:
+```bash
+python scripts/update_pricing.py --provider all
+```
+
+This fetches live prices from all provider APIs and updates exchange rates from the ECB.
 
 ## Emergency Stop
 
-If you need to stop everything RIGHT NOW:
+If you need to stop everything immediately:
 
-1. Go to Actions tab → Cancel any running workflows
-2. **Hetzner**: Go to Hetzner Console → Delete all `cloud-bench-*` servers, SSH keys, and firewalls
-3. **AWS**: Go to EC2 Console (eu-central-1) → Terminate all instances tagged `cloud-bench`, delete associated security groups and key pairs
-4. **OVHcloud**: Go to Horizon Dashboard → Delete all `cloud-bench-*` instances and associated key pairs
+1. Go to **Actions** tab — cancel any running workflows
+2. **Hetzner**: Hetzner Console → delete all `cloud-bench-*` servers, SSH keys, firewalls
+3. **AWS**: EC2 Console (eu-central-1) → terminate all `cloud-bench` tagged instances, delete security groups and key pairs
+4. **OVHcloud**: Horizon Dashboard (DE1) → delete all `cloud-bench-*` instances and key pairs
 
 ## Preventing Issues
 
-- **Always** wait for cleanup job to finish (green checkmark)
-- Don't run multiple benchmarks simultaneously (concurrency group prevents this)
-- Set a billing alert in Hetzner Console at €10, in AWS Budgets at $10, and in OVHcloud at €10
-- The orphan cleanup workflows run every 6 hours (Hetzner, AWS) or manual trigger (OVHcloud) as safety net
-
-## Getting Help
-
-If stuck, check:
-1. Workflow logs in GitHub Actions
-2. Hetzner Console / AWS EC2 Console / OVHcloud Horizon for resource status
-3. `terraform/terraform.tfstate` if running locally
+- Always wait for the cleanup job to finish (green checkmark)
+- Don't run multiple benchmarks simultaneously (concurrency group prevents this in CI)
+- Set billing alerts: €10 in Hetzner, $10 in AWS, €10 in OVHcloud
+- Keep pricing updated — stale prices affect value calculations

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- GitHub account
-- Hetzner Cloud account, AWS account, and/or OVHcloud account
+- GitHub account (for Actions-based benchmarking)
+- Account with one or more providers: Hetzner Cloud, AWS, OVHcloud
 
 ## Hetzner Setup
 
@@ -67,7 +67,7 @@ In [OVHcloud Control Panel](https://www.ovh.com/manager/), go to **Public Cloud 
 Download the OpenStack RC file or note the:
 - Username (format: `user-xxxxx`)
 - Password
-- Project ID
+- Project ID (found in Public Cloud > Project Settings)
 
 ### 3. Add secrets to GitHub
 
@@ -84,7 +84,11 @@ In OVHcloud Control Panel, set a budget alert as a safety net.
 
 Go to **Actions > Run Benchmarks > Run workflow**. Select provider `ovhcloud` and region `DE1`.
 
-## Local run
+Note: OVHcloud uses the OpenStack API and does not support security groups. Instances are protected by SSH key authentication only.
+
+## Local Run (Cloud Provisioning)
+
+Run the full benchmark pipeline locally (provisions cloud instances, runs benchmarks, processes results):
 
 ```bash
 # Hetzner
@@ -105,23 +109,32 @@ PROVIDER=ovhcloud ./scripts/run-local.sh
 
 The script auto-detects your IP for the firewall/security group. It provisions, benchmarks, processes results, and prompts to destroy.
 
+## Local Run (No Cloud)
+
+To benchmark your own machine without cloud credentials:
+
+```bash
+sudo bash scripts/run-local-bench.sh
+```
+
+See [local-benchmark.md](local-benchmark.md) for details.
+
 ## Verifying
 
 ```bash
 cd terraform
 terraform init
+
 # Hetzner
 terraform plan -var="run_id=test" -var="hcloud_token=$HCLOUD_TOKEN" -var='allowed_ssh_ips=["YOUR_IP/32"]'
+
 # AWS
 terraform plan -var="run_id=test" -var="cloud_provider=aws" -var='allowed_ssh_ips=["YOUR_IP/32"]'
+
 # OVHcloud
 terraform plan -var="run_id=test" -var="cloud_provider=ovhcloud" -var='allowed_ssh_ips=["YOUR_IP/32"]'
 ```
 
 ## Troubleshooting
 
-**SSH failures**: The workflow auto-whitelists the runner IP. For local runs, check that `ALLOWED_SSH_IPS` is set correctly. AWS and OVHcloud use `ubuntu` as the SSH user (not `root`).
-
-**Terraform errors**: Run `terraform init` and `terraform validate`. If state is stale, `terraform state list` to inspect.
-
-**Cleanup didn't run**: Delete resources manually in Hetzner Console / AWS EC2 Console / OVHcloud Horizon, or run `terraform destroy` from the `terraform/` directory.
+See [runbook.md](runbook.md) for common issues and fixes.

--- a/frontend/src/components/InstanceHistory.jsx
+++ b/frontend/src/components/InstanceHistory.jsx
@@ -248,26 +248,26 @@ function InstanceHistory({ instanceType, historyEntry, onClose, currency }) {
                   </td>
                   <td className="cell-numeric">
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                      <ScoreBar value={run.relative_scores?.single_core ?? 0} />
-                      <span>{(run.relative_scores?.single_core ?? 0).toFixed(0)}</span>
+                      <ScoreBar value={run.scores?.single_core ?? 0} />
+                      <span>{(run.scores?.single_core ?? 0).toFixed(1)}</span>
                     </div>
                   </td>
                   <td className="cell-numeric">
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                      <ScoreBar value={run.relative_scores?.multi_core ?? 0} />
-                      <span>{(run.relative_scores?.multi_core ?? 0).toFixed(0)}</span>
+                      <ScoreBar value={run.scores?.multi_core ?? 0} />
+                      <span>{(run.scores?.multi_core ?? 0).toFixed(1)}</span>
                     </div>
                   </td>
                   <td className="cell-numeric">
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                      <ScoreBar value={run.relative_scores?.memory ?? 0} />
-                      <span>{(run.relative_scores?.memory ?? 0).toFixed(0)}</span>
+                      <ScoreBar value={run.scores?.memory ?? 0} />
+                      <span>{(run.scores?.memory ?? 0).toFixed(1)}</span>
                     </div>
                   </td>
                   <td className="cell-numeric">
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                      <ScoreBar value={run.relative_scores?.disk ?? 0} />
-                      <span>{(run.relative_scores?.disk ?? 0).toFixed(0)}</span>
+                      <ScoreBar value={run.scores?.disk ?? 0} />
+                      <span>{(run.scores?.disk ?? 0).toFixed(1)}</span>
                     </div>
                   </td>
                   <td className="price-cell cell-numeric">
@@ -282,7 +282,7 @@ function InstanceHistory({ instanceType, historyEntry, onClose, currency }) {
         <p className="table-note">
           Showing {displayRuns.length} historical run{displayRuns.length !== 1 ? 's' : ''} for {instanceType}.
           <br />
-          Scores are relative to the best performance for this instance type (best = 100).
+          Chart shows relative performance (best run = 100). Table shows actual scores from each run.
         </p>
       </div>
     </div>

--- a/scripts/run-local-bench.sh
+++ b/scripts/run-local-bench.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# run-local-bench.sh — Run the same benchmarks used by cloud-bench on your own machine.
+# Usage: sudo bash scripts/run-local-bench.sh
+#
+# Supported: Debian/Ubuntu (apt), Arch/Manjaro (pacman), Fedora/RHEL (dnf/yum),
+#            openSUSE (zypper), Alpine (apk). Installs sysbench, fio, jq if missing.
+# Output: JSON result file + terminal summary table.
+
+set -euo pipefail
+
+NUM_RUNS=5
+SYSBENCH_CPU_PRIME=20000
+SYSBENCH_MEMORY_SIZE=1G
+FIO_SIZE=512M
+FIO_BLOCK_SIZE=4k
+FIO_IODEPTH=32
+FIO_RUNTIME=20
+
+RESULTS_DIR=$(mktemp -d)
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+OUTPUT_FILE="bench-$(hostname)-$(date +%Y%m%d-%H%M%S).json"
+
+cleanup() { rm -rf "$RESULTS_DIR"; }
+trap cleanup EXIT
+
+# --- helpers ----------------------------------------------------------------
+
+info()  { printf "\033[1;34m[*]\033[0m %s\n" "$*"; }
+ok()    { printf "\033[1;32m[+]\033[0m %s\n" "$*"; }
+err()   { printf "\033[1;31m[!]\033[0m %s\n" "$*" >&2; }
+
+median_of_file() {
+    local idx=$(( (NUM_RUNS + 1) / 2 ))
+    sort -n "$1" | sed -n "${idx}p"
+}
+
+# --- preflight --------------------------------------------------------------
+
+if [ "$(id -u)" -ne 0 ]; then
+    err "Please run as root: sudo bash $0"
+    exit 1
+fi
+
+info "Checking dependencies..."
+MISSING=()
+for tool in sysbench fio jq bc; do
+    command -v "$tool" &>/dev/null || MISSING+=("$tool")
+done
+
+install_packages() {
+    if command -v apt-get &>/dev/null; then
+        apt-get update -qq
+        apt-get install -y -qq "$@"
+    elif command -v pacman &>/dev/null; then
+        pacman -Sy --noconfirm "$@"
+    elif command -v dnf &>/dev/null; then
+        dnf install -y "$@"
+    elif command -v yum &>/dev/null; then
+        yum install -y "$@"
+    elif command -v zypper &>/dev/null; then
+        zypper install -y "$@"
+    elif command -v apk &>/dev/null; then
+        apk add "$@"
+    else
+        err "No supported package manager found (apt, pacman, dnf, yum, zypper, apk)"
+        err "Please install manually: $*"
+        exit 1
+    fi
+}
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    info "Installing: ${MISSING[*]}"
+    install_packages "${MISSING[@]}"
+fi
+
+VCPUS=$(nproc)
+info "Detected $VCPUS vCPU(s)"
+info "Running $NUM_RUNS iterations per benchmark (median taken)"
+echo
+
+# --- CPU single-thread ------------------------------------------------------
+
+info "CPU single-thread (sysbench cpu --threads=1 --cpu-max-prime=$SYSBENCH_CPU_PRIME)"
+for i in $(seq 1 $NUM_RUNS); do
+    sysbench cpu --cpu-max-prime=$SYSBENCH_CPU_PRIME --threads=1 run \
+        | grep "events per second" | awk '{print $4}'
+done > "$RESULTS_DIR/cpu-single-raw.txt"
+CPU_SINGLE=$(median_of_file "$RESULTS_DIR/cpu-single-raw.txt")
+ok "CPU single-thread: $CPU_SINGLE events/sec"
+
+# --- CPU multi-thread -------------------------------------------------------
+
+info "CPU multi-thread (sysbench cpu --threads=$VCPUS --cpu-max-prime=$SYSBENCH_CPU_PRIME)"
+for i in $(seq 1 $NUM_RUNS); do
+    sysbench cpu --cpu-max-prime=$SYSBENCH_CPU_PRIME --threads=$VCPUS run \
+        | grep "events per second" | awk '{print $4}'
+done > "$RESULTS_DIR/cpu-multi-raw.txt"
+CPU_MULTI=$(median_of_file "$RESULTS_DIR/cpu-multi-raw.txt")
+ok "CPU multi-thread:  $CPU_MULTI events/sec"
+
+# --- Memory read ------------------------------------------------------------
+
+info "Memory read (sysbench memory --memory-oper=read --memory-total-size=$SYSBENCH_MEMORY_SIZE)"
+for i in $(seq 1 $NUM_RUNS); do
+    sysbench memory --memory-oper=read --memory-total-size=$SYSBENCH_MEMORY_SIZE --threads=$VCPUS run \
+        | grep "transferred" | sed -n 's/.*(\([0-9.]*\) MiB\/sec.*/\1/p' | head -1
+done > "$RESULTS_DIR/mem-read-raw.txt"
+MEM_READ=$(median_of_file "$RESULTS_DIR/mem-read-raw.txt")
+ok "Memory read:       $MEM_READ MiB/sec"
+
+# --- Memory write -----------------------------------------------------------
+
+info "Memory write (sysbench memory --memory-oper=write --memory-total-size=$SYSBENCH_MEMORY_SIZE)"
+for i in $(seq 1 $NUM_RUNS); do
+    sysbench memory --memory-oper=write --memory-total-size=$SYSBENCH_MEMORY_SIZE --threads=$VCPUS run \
+        | grep "transferred" | sed -n 's/.*(\([0-9.]*\) MiB\/sec.*/\1/p' | head -1
+done > "$RESULTS_DIR/mem-write-raw.txt"
+MEM_WRITE=$(median_of_file "$RESULTS_DIR/mem-write-raw.txt")
+ok "Memory write:      $MEM_WRITE MiB/sec"
+
+# --- Disk IOPS --------------------------------------------------------------
+
+info "Disk IOPS (fio randread bs=$FIO_BLOCK_SIZE iodepth=$FIO_IODEPTH runtime=${FIO_RUNTIME}s)"
+for i in $(seq 1 $NUM_RUNS); do
+    fio --name=randread --ioengine=libaio --iodepth=$FIO_IODEPTH \
+        --rw=randread --bs=$FIO_BLOCK_SIZE --direct=1 --size=$FIO_SIZE \
+        --numjobs=1 --runtime=$FIO_RUNTIME \
+        --group_reporting --output-format=json \
+        | jq '.jobs[0].read.iops | round'
+done > "$RESULTS_DIR/disk-iops-raw.txt"
+DISK_IOPS=$(median_of_file "$RESULTS_DIR/disk-iops-raw.txt")
+ok "Disk IOPS:         $DISK_IOPS"
+
+# --- Compute totals ---------------------------------------------------------
+
+MEM_TOTAL=$(echo "$MEM_READ + $MEM_WRITE" | bc)
+
+# --- Build JSON output ------------------------------------------------------
+
+jq -n \
+    --arg hostname "$(hostname)" \
+    --arg timestamp "$TIMESTAMP" \
+    --argjson runs "$NUM_RUNS" \
+    --argjson vcpus "$VCPUS" \
+    --arg arch "$(uname -m)" \
+    --arg kernel "$(uname -r)" \
+    --argjson ram_kb "$(grep MemTotal /proc/meminfo | awk '{print $2}')" \
+    --argjson cpu_single "$CPU_SINGLE" \
+    --argjson cpu_multi "$CPU_MULTI" \
+    --argjson mem_read "$MEM_READ" \
+    --argjson mem_write "$MEM_WRITE" \
+    --argjson mem_total "$MEM_TOTAL" \
+    --argjson disk_iops "$DISK_IOPS" \
+    '{
+      hostname: $hostname,
+      timestamp: $timestamp,
+      benchmark_runs: $runs,
+      aggregation: "median",
+      system: {
+        arch: $arch,
+        kernel: $kernel,
+        vcpus: $vcpus,
+        ram_gb: (($ram_kb / 1048576) | round)
+      },
+      cpu: {
+        single_thread_events: $cpu_single,
+        multi_thread_events: $cpu_multi
+      },
+      memory: {
+        read_mib_per_sec: $mem_read,
+        write_mib_per_sec: $mem_write,
+        total_throughput_mib: $mem_total
+      },
+      disk: {
+        read_iops: $disk_iops
+      }
+    }' > "$OUTPUT_FILE"
+
+# --- Summary ----------------------------------------------------------------
+
+echo
+echo "================================================================"
+echo "  cloud-bench local results — $(hostname)"
+echo "================================================================"
+printf "  %-24s %s\n" "CPU single-thread:" "$CPU_SINGLE events/sec"
+printf "  %-24s %s\n" "CPU multi-thread:" "$CPU_MULTI events/sec"
+printf "  %-24s %s\n" "Memory read:" "$MEM_READ MiB/sec"
+printf "  %-24s %s\n" "Memory write:" "$MEM_WRITE MiB/sec"
+printf "  %-24s %s\n" "Memory total:" "$MEM_TOTAL MiB/sec"
+printf "  %-24s %s\n" "Disk IOPS:" "$DISK_IOPS"
+echo "================================================================"
+echo "  vCPUs: $VCPUS | Arch: $(uname -m) | Kernel: $(uname -r)"
+echo "  Results saved to: $OUTPUT_FILE"
+echo "================================================================"
+echo
+echo "Compare your results at https://fabianwimberger.github.io/cloud-bench/"


### PR DESCRIPTION
Summary:
  - Add standalone local benchmark script (run-local-bench.sh) supporting apt, pacman, dnf, yum, zypper, apk
  - Show actual scores in history table instead of relative scores (chart stays relative)
  - Overhaul all documentation and README to reflect current project state (19 instances, 3 providers)