### PR TITLE
Specific error messages for data loading failures

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,13 +13,13 @@ import './App.css'
 const DataAPI = {
   async loadBenchmarkData() {
     const response = await fetch('./data/benchmark-data.json')
-    if (!response.ok) throw new Error('Failed to load benchmark data')
+    if (!response.ok) throw new Error(`Failed to load benchmark-data.json (${response.status} ${response.statusText})`)
     return await response.json()
   },
 
   async loadHistory() {
     const response = await fetch('./data/history.json')
-    if (!response.ok) throw new Error('Failed to load history')
+    if (!response.ok) throw new Error(`Failed to load history.json (${response.status} ${response.statusText})`)
     return await response.json()
   }
 }
@@ -40,7 +40,7 @@ function parseExprFilter(expr, value) {
 
 function transformData(data) {
   if (!data || data.schema_version !== '2.0') {
-    throw new Error('Unsupported data format')
+    throw new Error(`Unsupported data format: expected schema v2.0, got v${data?.schema_version ?? 'unknown'}`)
   }
 
   const instances = data.summary?.instances || []
@@ -196,7 +196,7 @@ function App() {
         setHistoryData(data)
       } catch (err) {
         console.error('Failed to load history:', err)
-        setHistoryData({ instances: {} })
+        setHistoryData({ instances: {}, error: err.message })
       }
     }
   }, [historyData])
@@ -316,6 +316,7 @@ function App() {
         <InstanceHistory
           instanceType={selectedHistoryInstance}
           historyEntry={historyData?.instances?.[selectedHistoryInstance] || null}
+          historyError={historyData?.error || null}
           onClose={handleCloseHistory}
           currency={currencyProps}
         />

--- a/frontend/src/components/InstanceHistory.jsx
+++ b/frontend/src/components/InstanceHistory.jsx
@@ -5,7 +5,7 @@ import ProviderBadge from './ProviderBadge'
 
 Chart.register(...registerables)
 
-function InstanceHistory({ instanceType, historyEntry, onClose, currency }) {
+function InstanceHistory({ instanceType, historyEntry, historyError, onClose, currency }) {
   const chartRef = useRef(null)
   const chartInstance = useRef(null)
 
@@ -177,7 +177,9 @@ function InstanceHistory({ instanceType, historyEntry, onClose, currency }) {
             <div>
               <strong style={{ fontSize: '1.125rem' }}>{instanceType}</strong>
               <p style={{ color: 'var(--color-text-muted)', fontSize: '0.8125rem', marginTop: '0.25rem' }}>
-                No historical data available for this instance.
+                {historyError
+                  ? `Failed to load history: ${historyError}`
+                  : 'No historical data available for this instance.'}
               </p>
             </div>
             <button className="btn btn-ghost btn-small" onClick={onClose}>Close</button>


### PR DESCRIPTION
Previously all data loading errors showed generic messages that didn't help diagnose the actual problem.

- Fetch errors for benchmark-data.json and history.json now include the HTTP status code and status text
- Schema version mismatch error now shows the actual vs expected version
- History panel now displays the load error message instead of silently showing "No historical data available" 