### PR TITLE
Add Google Cloud Platform (GCP) to benchmarks

### DIFF
--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -18,20 +18,67 @@ jobs:
   cost-guard:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - name: Estimate Costs (All Providers)
         run: |
-          echo "## Cost Estimate" >> $GITHUB_STEP_SUMMARY
-          echo "| Provider | Instances | Est. Cost |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-----------|-----------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Hetzner  | 8         | ~€0.05    |" >> $GITHUB_STEP_SUMMARY
-          echo "| AWS      | 6         | ~\$0.15    |" >> $GITHUB_STEP_SUMMARY
-          echo "| OVHcloud | 5         | ~€0.15    |" >> $GITHUB_STEP_SUMMARY
-          echo "| OCI      | 3         | ~\$0.10    |" >> $GITHUB_STEP_SUMMARY
-          echo "| GCP      | 5         | ~\$0.10    |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Total estimated cost: ~\$0.50 / run**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Individual provider limits still apply (>\$5 blocks)." >> $GITHUB_STEP_SUMMARY
+          python3 - <<'SCRIPT'
+          import yaml
+          import os
+          
+          with open('config/instances.yaml') as f:
+              config = yaml.safe_load(f)
+          
+          exchange_rates = config.get('exchange_rates', {})
+          eur_to_usd = exchange_rates.get('eur_to_usd', 1.08)
+          
+          def estimate_provider(provider_name, currency):
+              provider = config.get('providers', {}).get(provider_name, {})
+              instances = provider.get('instances', [])
+              if not instances:
+                  return 0, 0, currency
+              
+              # Estimate for 1 hour of running all instances
+              total_hourly = sum(inst.get('pricing', {}).get('hourly', 0) for inst in instances)
+              
+              # Convert to USD for consistent comparison
+              if currency == 'EUR':
+                  total_usd = total_hourly * eur_to_usd
+              else:
+                  total_usd = total_hourly
+              
+              return len(instances), total_usd, currency
+          
+          providers = [
+              ('hetzner', 'EUR'),
+              ('aws', 'USD'),
+              ('ovhcloud', 'EUR'),
+              ('oci', 'USD'),
+              ('gcp', 'USD'),
+          ]
+          
+          summary = "## Cost Estimate\n\n"
+          summary += "| Provider | Instances | Est. Cost (1h) |\n"
+          summary += "|----------|-----------|----------------|\n"
+          
+          total_usd = 0
+          for name, currency in providers:
+              count, cost_usd, curr = estimate_provider(name, currency)
+              if count > 0:
+                  if curr == 'EUR':
+                      summary += f"| {name.capitalize():8} | {count:9} | ~€{cost_usd / eur_to_usd:.2f} |\n"
+                  else:
+                      summary += f"| {name.capitalize():8} | {count:9} | ~${cost_usd:.2f} |\n"
+                  total_usd += cost_usd
+          
+          summary += f"\n**Total estimated cost: ~${total_usd:.2f} / run**\n\n"
+          summary += "Individual provider limits still apply (>$5 blocks).\n"
+          
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write(summary)
+          
+          print(summary)
+          SCRIPT
           
           if [ "${{ inputs.skip_cost_guard }}" != "true" ]; then
             echo "Cost guard passed. Proceeding..."

--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -25,30 +25,30 @@ jobs:
           python3 - <<'SCRIPT'
           import yaml
           import os
-          
+
           with open('config/instances.yaml') as f:
               config = yaml.safe_load(f)
-          
+
           exchange_rates = config.get('exchange_rates', {})
           eur_to_usd = exchange_rates.get('eur_to_usd', 1.08)
-          
+
           def estimate_provider(provider_name, currency):
               provider = config.get('providers', {}).get(provider_name, {})
               instances = provider.get('instances', [])
               if not instances:
                   return 0, 0, currency
-              
+
               # Estimate for 1 hour of running all instances
               total_hourly = sum(inst.get('pricing', {}).get('hourly', 0) for inst in instances)
-              
+
               # Convert to USD for consistent comparison
               if currency == 'EUR':
                   total_usd = total_hourly * eur_to_usd
               else:
                   total_usd = total_hourly
-              
+
               return len(instances), total_usd, currency
-          
+
           providers = [
               ('hetzner', 'EUR'),
               ('aws', 'USD'),
@@ -56,11 +56,11 @@ jobs:
               ('oci', 'USD'),
               ('gcp', 'USD'),
           ]
-          
+
           summary = "## Cost Estimate\n\n"
           summary += "| Provider | Instances | Est. Cost (1h) |\n"
           summary += "|----------|-----------|----------------|\n"
-          
+
           total_usd = 0
           for name, currency in providers:
               count, cost_usd, curr = estimate_provider(name, currency)
@@ -70,16 +70,16 @@ jobs:
                   else:
                       summary += f"| {name.capitalize():8} | {count:9} | ~${cost_usd:.2f} |\n"
                   total_usd += cost_usd
-          
+
           summary += f"\n**Total estimated cost: ~${total_usd:.2f} / run**\n\n"
           summary += "Individual provider limits still apply (>$5 blocks).\n"
-          
+
           with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
               f.write(summary)
-          
+
           print(summary)
           SCRIPT
-          
+
           if [ "${{ inputs.skip_cost_guard }}" != "true" ]; then
             echo "Cost guard passed. Proceeding..."
           else

--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -27,6 +27,7 @@ jobs:
           echo "| AWS      | 6         | ~\$0.15    |" >> $GITHUB_STEP_SUMMARY
           echo "| OVHcloud | 5         | ~€0.15    |" >> $GITHUB_STEP_SUMMARY
           echo "| OCI      | 3         | ~\$0.10    |" >> $GITHUB_STEP_SUMMARY
+          echo "| GCP      | 5         | ~\$0.10    |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Total estimated cost: ~\$0.50 / run**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -62,6 +63,9 @@ jobs:
             instances: all
           - provider: oci
             region: eu-frankfurt-1
+            instances: all
+          - provider: gcp
+            region: europe-west3
             instances: all
     steps:
       - uses: actions/checkout@v6
@@ -144,6 +148,8 @@ jobs:
           TF_VAR_oci_fingerprint: ${{ secrets.OCI_FINGERPRINT || 'unused' }}
           TF_VAR_oci_private_key: ${{ secrets.OCI_PRIVATE_KEY || 'unused' }}
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
+          TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
+          TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
         run: |
           terraform apply -auto-approve \
             -var="run_id=${{ github.run_id }}-${{ matrix.provider }}" \
@@ -222,6 +228,8 @@ jobs:
           TF_VAR_oci_fingerprint: ${{ secrets.OCI_FINGERPRINT || 'unused' }}
           TF_VAR_oci_private_key: ${{ secrets.OCI_PRIVATE_KEY || 'unused' }}
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
+          TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
+          TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
         run: |
           terraform destroy -auto-approve \
             -var="run_id=${{ github.run_id }}-${{ matrix.provider }}" \
@@ -304,6 +312,18 @@ jobs:
             else
               echo "[OK] OCI resources cleaned up successfully"
             fi
+
+          elif [ "${{ matrix.provider }}" = "gcp" ]; then
+            cd terraform
+            REMAINING=$(terraform state list 2>/dev/null | grep -c "google_compute_instance" || true)
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "::error::CRITICAL: GCP instances still in Terraform state after cleanup!"
+              terraform state list | grep "google_compute_instance"
+              echo "Manual intervention required!"
+              exit 1
+            else
+              echo "[OK] GCP resources cleaned up successfully"
+            fi
           fi
 
   # Serialize access to benchmark-data branch to prevent race conditions
@@ -353,10 +373,10 @@ jobs:
           fi
 
           # Region mapping (must match matrix above)
-          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 )
+          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 )
 
           # Process each provider's results
-          for provider in hetzner aws ovhcloud oci; do
+          for provider in hetzner aws ovhcloud oci gcp; do
             PROVIDER_DIR="artifacts/results-$provider"
             if [ -d "$PROVIDER_DIR" ]; then
               REGION="${REGIONS[$provider]}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ on:
           - aws
           - ovhcloud
           - oci
+          - gcp
 
       instances:
         description: 'Instance IDs (comma-separated, or "all")'
@@ -77,6 +78,7 @@ jobs:
               aws)      REGION="eu-central-1" ;;
               ovhcloud) REGION="DE1" ;;
               oci)      REGION="eu-frankfurt-1" ;;
+              gcp)      REGION="europe-west3" ;;
             esac
           fi
           echo "region=$REGION" >> $GITHUB_OUTPUT
@@ -104,6 +106,11 @@ jobs:
           OCI_KEY_SET="${{ secrets.OCI_TENANCY_OCID != '' }}"
           if [ "${{ github.event.inputs.provider }}" = "oci" ] && [ "$OCI_KEY_SET" != "true" ]; then
             echo "::error::OCI_TENANCY_OCID, OCI_USER_OCID, OCI_FINGERPRINT, OCI_PRIVATE_KEY, and OCI_COMPARTMENT_ID secrets are required for OCI"
+            exit 1
+          fi
+          GCP_KEY_SET="${{ secrets.GCP_CREDENTIALS != '' }}"
+          if [ "${{ github.event.inputs.provider }}" = "gcp" ] && [ "$GCP_KEY_SET" != "true" ]; then
+            echo "::error::GCP_CREDENTIALS and GCP_PROJECT_ID secrets are required for GCP"
             exit 1
           fi
           if [ -n "$INSTANCE_REGIONS" ] && [ "$INSTANCE_REGIONS" != "{}" ]; then
@@ -188,6 +195,8 @@ jobs:
           TF_VAR_oci_fingerprint: ${{ secrets.OCI_FINGERPRINT || 'unused' }}
           TF_VAR_oci_private_key: ${{ secrets.OCI_PRIVATE_KEY || 'unused' }}
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
+          TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
+          TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
         run: |
           terraform apply -auto-approve \
             -var="run_id=${{ env.RUN_ID }}" \
@@ -274,6 +283,36 @@ jobs:
             aws ec2 authorize-security-group-ingress --group-id "$sg" \
               --protocol icmp --port -1 --cidr "$RUNNER_IP/32" || true
           done
+
+      - name: Update GCP Firewall Rules with Runner IP
+        if: ${{ github.event.inputs.provider == 'gcp' }}
+        env:
+          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          RUNNER_IP=$(curl -s --retry 3 https://ifconfig.me || curl -s --retry 3 https://api.ipify.org)
+          echo "Benchmark runner IP: $RUNNER_IP"
+          PREV_IP="${{ needs.provision.outputs.runner_ip }}"
+          echo "Provision runner IP: $PREV_IP"
+          if [ "$RUNNER_IP" = "$PREV_IP" ]; then
+            echo "Same IP, no update needed"
+            exit 0
+          fi
+
+          # Write credentials to temp file for gcloud auth
+          echo "$GCP_CREDENTIALS" > /tmp/gcp-key.json
+          gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
+          gcloud config set project "$GCP_PROJECT_ID"
+
+          # Find cloud-bench firewall rules for this run and add the new IP
+          RULES=$(gcloud compute firewall-rules list --filter="name~cloud-bench.*${{ env.RUN_ID }}" --format="value(name)")
+          for rule in $RULES; do
+            echo "Updating firewall rule: $rule"
+            EXISTING=$(gcloud compute firewall-rules describe "$rule" --format="value(sourceRanges)")
+            gcloud compute firewall-rules update "$rule" \
+              --source-ranges="${EXISTING},${RUNNER_IP}/32" || true
+          done
+          rm -f /tmp/gcp-key.json
 
       - name: Update OCI Security Lists with Runner IP
         if: ${{ github.event.inputs.provider == 'oci' }}
@@ -570,6 +609,8 @@ jobs:
           TF_VAR_oci_fingerprint: ${{ secrets.OCI_FINGERPRINT || 'unused' }}
           TF_VAR_oci_private_key: ${{ secrets.OCI_PRIVATE_KEY || 'unused' }}
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
+          TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
+          TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
         run: |
           terraform destroy -auto-approve \
             -var="run_id=${{ env.RUN_ID }}" \
@@ -658,6 +699,18 @@ jobs:
               exit 1
             else
               echo "[OK] OCI resources cleaned up successfully"
+            fi
+
+          elif [ "${{ github.event.inputs.provider }}" = "gcp" ]; then
+            cd terraform
+            REMAINING=$(terraform state list 2>/dev/null | grep -c "google_compute_instance" || true)
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "::error::CRITICAL: GCP instances still in Terraform state after cleanup!"
+              terraform state list | grep "google_compute_instance"
+              echo "Manual intervention required!"
+              exit 1
+            else
+              echo "[OK] GCP resources cleaned up successfully"
             fi
           fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -285,6 +285,12 @@ jobs:
               --protocol icmp --port -1 --cidr "$RUNNER_IP/32" || true
           done
 
+      - name: Setup gcloud CLI
+        if: ${{ github.event.inputs.provider == 'gcp' }}
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
       - name: Update GCP Firewall Rules with Runner IP
         if: ${{ github.event.inputs.provider == 'gcp' }}
         env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,7 +109,8 @@ jobs:
             exit 1
           fi
           GCP_KEY_SET="${{ secrets.GCP_CREDENTIALS != '' }}"
-          if [ "${{ github.event.inputs.provider }}" = "gcp" ] && [ "$GCP_KEY_SET" != "true" ]; then
+          GCP_PROJECT_SET="${{ secrets.GCP_PROJECT_ID != '' }}"
+          if [ "${{ github.event.inputs.provider }}" = "gcp" ] && { [ "$GCP_KEY_SET" != "true" ] || [ "$GCP_PROJECT_SET" != "true" ]; }; then
             echo "::error::GCP_CREDENTIALS and GCP_PROJECT_ID secrets are required for GCP"
             exit 1
           fi
@@ -301,6 +302,8 @@ jobs:
 
           # Write credentials to temp file for gcloud auth
           echo "$GCP_CREDENTIALS" > /tmp/gcp-key.json
+          # Ensure cleanup happens even if subsequent commands fail
+          trap 'rm -f /tmp/gcp-key.json' EXIT
           gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
           gcloud config set project "$GCP_PROJECT_ID"
 
@@ -309,8 +312,20 @@ jobs:
           for rule in $RULES; do
             echo "Updating firewall rule: $rule"
             EXISTING=$(gcloud compute firewall-rules describe "$rule" --format="value(sourceRanges)")
+            NEW_IP="${RUNNER_IP}/32"
+            # Check if IP already exists to avoid duplicates
+            if echo "$EXISTING" | grep -q "${NEW_IP}"; then
+              echo "IP ${NEW_IP} already in source ranges, skipping update"
+              continue
+            fi
+            # Handle empty existing ranges
+            if [ -z "$EXISTING" ]; then
+              UPDATED_RANGES="$NEW_IP"
+            else
+              UPDATED_RANGES="${EXISTING},${NEW_IP}"
+            fi
             gcloud compute firewall-rules update "$rule" \
-              --source-ranges="${EXISTING},${RUNNER_IP}/32" || true
+              --source-ranges="$UPDATED_RANGES" || true
           done
           rm -f /tmp/gcp-key.json
 
@@ -703,10 +718,11 @@ jobs:
 
           elif [ "${{ github.event.inputs.provider }}" = "gcp" ]; then
             cd terraform
-            REMAINING=$(terraform state list 2>/dev/null | grep -c "google_compute_instance" || true)
-            if [ "$REMAINING" -gt 0 ]; then
-              echo "::error::CRITICAL: GCP instances still in Terraform state after cleanup!"
-              terraform state list | grep "google_compute_instance"
+            REMAINING_INSTANCES=$(terraform state list 2>/dev/null | grep -c "google_compute_instance" || true)
+            REMAINING_FIREWALLS=$(terraform state list 2>/dev/null | grep -c "google_compute_firewall" || true)
+            if [ "$REMAINING_INSTANCES" -gt 0 ] || [ "$REMAINING_FIREWALLS" -gt 0 ]; then
+              echo "::error::CRITICAL: GCP resources still in Terraform state after cleanup!"
+              terraform state list | grep -E "google_compute_instance|google_compute_firewall"
               echo "Manual intervention required!"
               exit 1
             else

--- a/.github/workflows/cleanup/cleanup-gcp.yml
+++ b/.github/workflows/cleanup/cleanup-gcp.yml
@@ -1,0 +1,61 @@
+name: Cleanup GCP Orphans
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Find and terminate orphaned instances
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "GCP credentials not configured, skipping"
+            exit 0
+          fi
+
+          echo "Checking for orphaned cloud-bench instances..."
+
+          INSTANCES=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.project=cloud-bench" \
+            --format="value(name,zone,creationTimestamp,labels.run_id)")
+
+          if [ -z "$INSTANCES" ]; then
+            echo "[OK] No cloud-bench instances found"
+            exit 0
+          fi
+
+          echo "Found instances:"
+          echo "$INSTANCES"
+
+          CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%S)
+          TERMINATED=0
+
+          while IFS=$'\t' read -r name zone created run_id; do
+            if [[ "$created" < "$CUTOFF" ]]; then
+              echo "Terminating orphaned instance: $name (zone: $zone, created: $created, run_id: $run_id)"
+              gcloud compute instances delete "$name" --zone="$zone" --project="$GCP_PROJECT_ID" --quiet
+              TERMINATED=$((TERMINATED + 1))
+            else
+              echo "Keeping recent instance: $name (created: $created)"
+            fi
+          done <<< "$INSTANCES"
+
+          echo ""
+          echo "Summary: Terminated $TERMINATED orphaned instance(s)"
+
+          if [ $TERMINATED -gt 0 ]; then
+            echo "## GCP Orphan Cleanup" >> $GITHUB_STEP_SUMMARY
+            echo "Terminated **$TERMINATED** orphaned instance(s) older than 2 hours." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,6 +49,7 @@ jobs:
             -var="ovh_openstack_username=unused" \
             -var="ovh_openstack_password=unused" \
             -var="ovh_cloud_project_id=unused" \
+            -var="gcp_project_id=unused" \
             -var='allowed_ssh_ips=["10.0.0.1/32"]' \
             -input=false 2>&1 | tee plan_output.txt || {
             # Exit code 1 is expected (invalid token), exit code >1 indicates real errors

--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -28,13 +28,6 @@ jobs:
       - name: Install dependencies
         run: pip install requests pyyaml boto3 google-cloud-billing
 
-      - name: Setup GCP Credentials
-        if: ${{ secrets.GCP_CREDENTIALS != '' }}
-        run: |
-          echo "${{ secrets.GCP_CREDENTIALS }}" > /tmp/gcp-key.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
-          trap 'rm -f /tmp/gcp-key.json' EXIT
-
       - name: Check pricing
         id: check
         env:
@@ -42,8 +35,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
         run: |
+          # Setup GCP credentials if available
+          if [ -n "$GCP_CREDENTIALS" ]; then
+            echo "$GCP_CREDENTIALS" > /tmp/gcp-key.json
+            export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json
+            trap 'rm -f /tmp/gcp-key.json' EXIT
+          fi
           if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
             python scripts/update_pricing.py --provider all --dry-run | tee pricing_output.txt
           else

--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: pip install requests pyyaml boto3
+        run: pip install requests pyyaml boto3 google-cloud-billing
 
       - name: Check pricing
         id: check
@@ -56,7 +56,7 @@ jobs:
           commit-message: 'chore: update instance pricing from cloud APIs'
           title: 'chore: Update instance pricing'
           body: |
-            Automated pricing update from Hetzner Cloud API, AWS Pricing API, OVH Catalog API, and OCI Pricing.
+            Automated pricing update from Hetzner Cloud API, AWS Pricing API, OVH Catalog API, OCI Pricing, and GCP Cloud Billing API.
 
             Changes detected in `config/instances.yaml`.
 

--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Install dependencies
         run: pip install requests pyyaml boto3 google-cloud-billing
 
+      - name: Setup GCP Credentials
+        if: ${{ secrets.GCP_CREDENTIALS != '' }}
+        run: |
+          echo "${{ secrets.GCP_CREDENTIALS }}" > /tmp/gcp-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
+          trap 'rm -f /tmp/gcp-key.json' EXIT
+
       - name: Check pricing
         id: check
         env:
@@ -35,6 +42,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
         run: |
           if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
             python scripts/update_pricing.py --provider all --dry-run | tee pricing_output.txt

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -459,6 +459,70 @@ jobs:
           print('OCI currency check passed: USD')
           "
 
+      - name: Create Mock Results (GCP)
+        run: |
+          rm -f results/*.json
+          cat > results/e2-standard-2-mock.json << 'MOCKEOF'
+          {
+            "run_id": "test-mock-gcp",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "system": {
+              "provider": "gcp",
+              "instance_type": "e2-standard-2"
+            },
+            "provider_attributes": {
+              "arch": "x86_64",
+              "os": "Ubuntu 24.04",
+              "kernel": "6.8.0",
+              "vcpu": 2,
+              "memory_mb": 8192,
+              "hostname": "test-e2-standard-2"
+            },
+            "cpu": {
+              "test": "sysbench-cpu",
+              "runs": 5,
+              "single_thread_events": 410,
+              "multi_thread_events": 820,
+              "threads": 2
+            },
+            "memory": {
+              "test": "sysbench-memory",
+              "runs": 5,
+              "read_mib_per_sec": 7800,
+              "write_mib_per_sec": 5900,
+              "total_throughput_mib": 13700
+            },
+            "disk": {
+              "test": "fio-randread",
+              "runs": 5,
+              "read_iops": 15000
+            }
+          }
+          MOCKEOF
+
+      - name: Test Result Processing (GCP)
+        run: |
+          mkdir -p frontend/public/data-gcp/
+          python3 scripts/process_results.py \
+            --input results/ \
+            --output frontend/public/data-gcp/ \
+            --config config/instances.yaml \
+            --region europe-west3 \
+            --provider gcp
+
+      - name: Verify GCP Output Files
+        run: |
+          for f in benchmark-data.json benchmark-results.csv summary.md; do
+            test -f "frontend/public/data-gcp/$f" || (echo "$f missing" && exit 1)
+          done
+          # Verify currency is USD
+          python3 -c "
+          import json
+          data = json.load(open('frontend/public/data-gcp/benchmark-data.json'))
+          assert data['metadata']['currency'] == 'USD', f'Expected USD, got {data[\"metadata\"][\"currency\"]}'
+          print('GCP currency check passed: USD')
+          "
+
       - name: Build Frontend with Real Data
         working-directory: frontend
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Live Results](https://img.shields.io/badge/Live%20Results-View%20Dashboard-blue)](https://fabianwimberger.github.io/cloud-bench/)
 
-A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 23 instance types across Hetzner Cloud, AWS EC2, OVHcloud, and Oracle Cloud (OCI).
+A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 28 instance types across Hetzner Cloud, AWS EC2, OVHcloud, Oracle Cloud (OCI), and Google Cloud Platform (GCP).
 
 ## Why This Project?
 
@@ -56,6 +56,11 @@ export OVH_OPENSTACK_PASSWORD="your-password"
 export OVH_CLOUD_PROJECT_ID="your-project-id"
 PROVIDER=ovhcloud ./scripts/run-local.sh
 
+# GCP
+export GCP_PROJECT_ID="your-project-id"
+export GCP_CREDENTIALS='{"type": "service_account", ...}'  # Service account JSON key
+PROVIDER=gcp ./scripts/run-local.sh
+
 # Or run via GitHub Actions: Actions > Run Benchmarks
 ```
 
@@ -98,7 +103,7 @@ No code changes needed — Terraform, Ansible, and the frontend all pick up conf
 
 ## Features
 
-- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI (23 instance types)
+- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI, GCP (28 instance types)
 - **Standardized benchmarks** — CPU (sysbench), Memory (sysbench), Disk I/O (fio)
 - **Metric averaging** — scores based on all historical runs, not just the latest
 - **Cost analysis** — performance per dollar with EUR/USD toggle

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -253,8 +253,8 @@ providers:
       ram_gb: 8
       disk_gb: 20
       pricing:
-        hourly: 0.07672
-        monthly: 55.24
+        hourly: 0.08915
+        monthly: 64.19
     - id: n2-standard-2
       name: N2 Standard 2
       arch: X86
@@ -262,8 +262,8 @@ providers:
       ram_gb: 8
       disk_gb: 20
       pricing:
-        hourly: 0.11312
-        monthly: 81.45
+        hourly: 0.1292
+        monthly: 93.02
     - id: n2d-standard-2
       name: N2D Standard 2
       arch: X86
@@ -271,8 +271,8 @@ providers:
       ram_gb: 8
       disk_gb: 20
       pricing:
-        hourly: 0.09868
-        monthly: 71.05
+        hourly: 0.10885
+        monthly: 78.37
     - id: t2d-standard-2
       name: T2D Standard 2
       arch: X86
@@ -280,8 +280,8 @@ providers:
       ram_gb: 8
       disk_gb: 20
       pricing:
-        hourly: 0.09448
-        monthly: 68.03
+        hourly: 0.10885
+        monthly: 78.37
     - id: c4a-standard-2
       name: C4A Standard 2
       arch: ARM64
@@ -289,14 +289,14 @@ providers:
       ram_gb: 8
       disk_gb: 20
       pricing:
-        hourly: 0.0
-        monthly: 0.0
+        hourly: 0.10597
+        monthly: 76.3
 exchange_rates:
   eur_to_usd: 1.1702
   usd_to_eur: 0.8546
   last_updated: '2026-04-30'
   source: Frankfurter API (ECB data)
 _metadata:
-  last_pricing_update: '2026-05-01T21:54:54.753556'
+  last_pricing_update: '2026-05-02T09:39:29.757001'
   source: Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing
-    API
+    API / GCP Cloud Billing API

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -291,6 +291,15 @@ providers:
       pricing:
         hourly: 0.08008
         monthly: 57.66
+    - id: c4a-standard-2
+      name: C4A Standard 2
+      arch: ARM64
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.0
+        monthly: 0.0
 exchange_rates:
   eur_to_usd: 1.1702
   usd_to_eur: 0.8546

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -239,6 +239,58 @@ providers:
       pricing:
         hourly: 0.036
         monthly: 25.92
+  gcp:
+    currency: USD
+    default_region: europe-west3
+    regions:
+      europe-west3:
+        name: Frankfurt
+    instances:
+    - id: e2-standard-2
+      name: E2 Standard 2
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.07672
+        monthly: 55.24
+    - id: n2-standard-2
+      name: N2 Standard 2
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.11312
+        monthly: 81.45
+    - id: n2d-standard-2
+      name: N2D Standard 2
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.09868
+        monthly: 71.05
+    - id: t2d-standard-2
+      name: T2D Standard 2
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.09448
+        monthly: 68.03
+    - id: t2a-standard-2
+      name: T2A Standard 2
+      arch: ARM64
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 20
+      pricing:
+        hourly: 0.08008
+        monthly: 57.66
 exchange_rates:
   eur_to_usd: 1.1525
   usd_to_eur: 0.8677

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -282,15 +282,6 @@ providers:
       pricing:
         hourly: 0.09448
         monthly: 68.03
-    - id: t2a-standard-2
-      name: T2A Standard 2
-      arch: ARM64
-      vcpu: 2
-      ram_gb: 8
-      disk_gb: 20
-      pricing:
-        hourly: 0.08008
-        monthly: 57.66
     - id: c4a-standard-2
       name: C4A Standard 2
       arch: ARM64

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - GitHub account (for Actions-based benchmarking)
-- Account with one or more providers: Hetzner Cloud, AWS, OVHcloud, Oracle Cloud (OCI)
+- Account with one or more providers: Hetzner Cloud, AWS, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP)
 
 ## Hetzner Setup
 
@@ -155,6 +155,56 @@ In OCI Console, go to **Billing & Cost Management > Budgets** and create a budge
 
 Go to **Actions > Run Benchmarks > Run workflow**. Select provider `oci` and region `eu-frankfurt-1`.
 
+## GCP Setup
+
+### 1. Create a dedicated GCP project
+
+In [Google Cloud Console](https://console.cloud.google.com/), create a new project (e.g., "cloud-bench"). This isolates resources and makes billing tracking easier.
+
+### 2. Enable required APIs
+
+Navigate to **APIs & Services > Library** and enable:
+- Compute Engine API
+- Cloud Billing API (for automated pricing updates)
+
+### 3. Create a service account
+
+**IAM & Admin > Service Accounts > Create Service Account**:
+- Name: `cloud-bench`
+- Description: Cloud benchmark automation
+
+Grant the following roles:
+- **Compute Admin** (for creating instances and firewall rules)
+- **Compute Viewer** (read-only access to compute resources)
+- **Billing Account Viewer** (for pricing data)
+
+### 4. Create and download a service account key
+
+**IAM & Admin > Service Accounts > cloud-bench > Keys > Add Key > Create New Key**.
+
+Choose JSON format and download the key file.
+
+### 5. Collect required identifiers
+
+| Secret | Where to find it |
+|---|---|
+| `GCP_PROJECT_ID` | Project selector dropdown — the project ID (not name) |
+| `GCP_CREDENTIALS` | The entire JSON content of the downloaded key file |
+
+### 6. Add secrets to GitHub
+
+**Repository Settings > Secrets and variables > Actions** — add:
+- `GCP_PROJECT_ID` — the project ID string
+- `GCP_CREDENTIALS` — the full JSON service account key
+
+### 7. Set a budget alert
+
+In GCP Console, go to **Billing > Budgets & alerts** and create a budget at e.g. $10.
+
+### 8. Run
+
+Go to **Actions > Run Benchmarks > Run workflow**. Select provider `gcp` and region `europe-west3`.
+
 ## Local Run (Cloud Provisioning)
 
 Run the full benchmark pipeline locally (provisions cloud instances, runs benchmarks, processes results):
@@ -182,6 +232,11 @@ export OCI_FINGERPRINT="aa:bb:cc:..."
 export OCI_PRIVATE_KEY="$(cat ~/.oci/oci_api_key.pem)"
 export OCI_COMPARTMENT_ID="ocid1.compartment.oc1..xxx"
 PROVIDER=oci ./scripts/run-local.sh
+
+# GCP
+export GCP_PROJECT_ID="your-project-id"
+export GCP_CREDENTIALS="$(cat /path/to/service-account-key.json)"
+PROVIDER=gcp ./scripts/run-local.sh
 ```
 
 The script auto-detects your IP for the firewall/security group. It provisions, benchmarks, processes results, and prompts to destroy.
@@ -213,6 +268,9 @@ terraform plan -var="run_id=test" -var="cloud_provider=ovhcloud" -var='allowed_s
 
 # OCI
 terraform plan -var="run_id=test" -var="cloud_provider=oci" -var='allowed_ssh_ips=["YOUR_IP/32"]'
+
+# GCP
+terraform plan -var="run_id=test" -var="cloud_provider=gcp" -var='allowed_ssh_ips=["YOUR_IP/32"]'
 ```
 
 ## Troubleshooting

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.42.83
+google-cloud-billing==1.19.0
 numpy==2.4.4
 pandas==3.0.2
 pyyaml==6.0.3

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Local benchmark runner script (supports Hetzner, AWS, OVHcloud, and OCI)
+# Local benchmark runner script (supports Hetzner, AWS, OVHcloud, OCI, and GCP)
 set -e
 
 # Configuration
@@ -15,6 +15,7 @@ if [ -z "$REGION" ]; then
         aws)      REGION="eu-central-1" ;;
         ovhcloud) REGION="DE1" ;;
         oci)      REGION="eu-frankfurt-1" ;;
+        gcp)      REGION="europe-west3" ;;
         *)        REGION="fsn1" ;;
     esac
 fi
@@ -108,6 +109,18 @@ validate_credentials() {
                 exit 1
             fi
             ;;
+        gcp)
+            local gcp_missing=()
+            [ -z "$GCP_PROJECT_ID" ] && gcp_missing+=("GCP_PROJECT_ID")
+            [ -z "$GCP_CREDENTIALS" ] && gcp_missing+=("GCP_CREDENTIALS")
+            if [ ${#gcp_missing[@]} -ne 0 ]; then
+                echo "[ERROR] GCP credentials not set: ${gcp_missing[*]}"
+                echo "Set them with:"
+                echo "  export GCP_PROJECT_ID=your-project-id"
+                echo "  export GCP_CREDENTIALS=\$(cat /path/to/service-account-key.json)"
+                exit 1
+            fi
+            ;;
         *)
             echo "[ERROR] Unsupported provider: $PROVIDER"
             exit 1
@@ -194,6 +207,18 @@ build_tf_vars() {
                 -var="oci_fingerprint=$OCI_FINGERPRINT"
                 -var="oci_private_key=$OCI_PRIVATE_KEY"
                 -var="oci_compartment_id=$OCI_COMPARTMENT_ID"
+            )
+            ;;
+        gcp)
+            common_vars+=(
+                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
+                -var="aws_access_key_id=unused"
+                -var="aws_secret_access_key=unused"
+                -var="ovh_openstack_username=unused"
+                -var="ovh_openstack_password=unused"
+                -var="ovh_cloud_project_id=unused"
+                -var="gcp_project_id=$GCP_PROJECT_ID"
+                -var="gcp_credentials=$GCP_CREDENTIALS"
             )
             ;;
     esac

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -399,6 +399,142 @@ def fetch_oci_pricing(config: dict, oci_region: str = "eu-frankfurt-1") -> int:
     return updated
 
 
+def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
+    """Fetch GCP pricing using the Cloud Billing Catalog API.
+    Returns count of updated instances."""
+    try:
+        from google.cloud import billing_v1
+    except ImportError:
+        print(
+            "  [WARN] google-cloud-billing not installed, skipping GCP pricing update"
+        )
+        return 0
+
+    gcp_config = config.get("providers", {}).get("gcp", {})
+    instances = gcp_config.get("instances", [])
+    if not instances:
+        print("  [WARN] No GCP instances in config")
+        return 0
+
+    # Compute Engine service ID
+    service_name = "services/6F81-5844-456A"
+
+    try:
+        client = billing_v1.CloudCatalogClient()
+        request = billing_v1.ListSkusRequest(parent=service_name)
+
+        # Build a map of machine type -> hourly price for the target region
+        # GCP SKU descriptions contain the machine type and region info
+        # Region mapping for SKU filtering
+        region_prefix = gcp_region.split("-")[0] + "-" + gcp_region.split("-")[1]
+
+        # Collect per-vCPU and per-GB rates by machine series
+        series_rates: dict[str, dict[str, float]] = {}
+
+        for sku in client.list_skus(request=request):
+            # Only consider on-demand compute SKUs in our region
+            if not any(region_prefix in region for region in sku.service_regions):
+                continue
+
+            desc = sku.description.lower()
+            category = sku.category
+
+            if category.resource_family != "Compute":
+                continue
+            if category.usage_type != "OnDemand":
+                continue
+
+            # Identify machine series from resource group
+            resource_group = category.resource_group.lower()
+
+            # Map resource groups to series keys
+            # Order matters: check longer prefixes first (n2d before n2, t2d before t2a)
+            series_key = None
+            if "n2d" in resource_group:
+                series_key = "n2d"
+            elif "n2" in resource_group:
+                series_key = "n2"
+            elif "e2" in resource_group:
+                series_key = "e2"
+            elif "t2d" in resource_group:
+                series_key = "t2d"
+            elif "t2a" in resource_group:
+                series_key = "t2a"
+            else:
+                continue
+
+            # Determine rate type (cpu or ram)
+            rate_type = None
+            if "core" in desc or "cpu" in desc or "vcpu" in desc:
+                rate_type = "cpu_hr"
+            elif "ram" in desc or "memory" in desc:
+                rate_type = "gb_hr"
+            else:
+                continue
+
+            # Extract price from tiered rates (first tier)
+            for tier in sku.pricing_info:
+                for rate in tier.pricing_expression.tiered_rates:
+                    price = rate.unit_price.units + rate.unit_price.nanos / 1e9
+                    if price > 0:
+                        if series_key not in series_rates:
+                            series_rates[series_key] = {}
+                        series_rates[series_key][rate_type] = price
+                        break
+                break
+
+        if not series_rates:
+            print(f"  [WARN] No GCP pricing rates found for region {gcp_region}")
+            return 0
+
+        print(
+            f"  [OK] Fetched rates for {len(series_rates)} machine series: "
+            f"{', '.join(sorted(series_rates.keys()))}"
+        )
+
+    except Exception as e:
+        print(f"  [WARN] Failed to fetch GCP pricing: {e}")
+        return 0
+
+    # Map machine type to series key (e.g. "n2d-standard-2" -> "n2d")
+    def _get_series(machine_type: str) -> str | None:
+        series = machine_type.split("-")[0]  # e2, n2, n2d, t2d, t2a
+        if series in series_rates:
+            return series
+        return None
+
+    updated = 0
+    for inst in instances:
+        inst_id = inst.get("id", "")
+        vcpu = inst.get("vcpu", 0)
+        ram_gb = inst.get("ram_gb", 0)
+
+        series = _get_series(inst_id)
+        if not series or series not in series_rates:
+            print(f"  [WARN] No pricing rates for machine type '{inst_id}'")
+            continue
+
+        rates = series_rates[series]
+        cpu_rate = rates.get("cpu_hr", 0)
+        gb_rate = rates.get("gb_hr", 0)
+
+        hourly = round(vcpu * cpu_rate + ram_gb * gb_rate, 5)
+        monthly = round(hourly * 720, 2)
+
+        old_pricing = inst.get("pricing", {})
+        if old_pricing.get("hourly") != hourly or old_pricing.get("monthly") != monthly:
+            inst["pricing"] = {"hourly": hourly, "monthly": monthly}
+            updated += 1
+            print(
+                f"  [UPDATED] {inst_id}: ${monthly}/mo "
+                f"(${cpu_rate}/vCPU-hr + ${gb_rate}/GB-hr)"
+            )
+        else:
+            print(f"  [OK] {inst_id}: ${monthly}/mo (unchanged)")
+
+    return updated
+
+
 def fetch_exchange_rates() -> dict:
     """Fetch EUR/USD rate from Frankfurter API (ECB data, free, no key)."""
     try:
@@ -454,6 +590,11 @@ def update_config(
         print("\nUpdating OCI pricing...")
         total_updated += fetch_oci_pricing(config)
 
+    # Update GCP pricing
+    if provider in ("all", "gcp"):
+        print("\nUpdating GCP pricing...")
+        total_updated += fetch_gcp_pricing(config)
+
     # Update exchange rates
     print("\nFetching exchange rates...")
     exchange_rates = fetch_exchange_rates()
@@ -471,7 +612,7 @@ def update_config(
     if not dry_run and total_updated > 0:
         config["_metadata"] = {
             "last_pricing_update": datetime.now().isoformat(),
-            "source": "Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing API",
+            "source": "Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing API / GCP Cloud Billing API",
         }
         with open(config_path, "w") as f:
             yaml.dump(
@@ -498,7 +639,7 @@ def main():
         "--provider",
         "-p",
         default="all",
-        choices=["hetzner", "aws", "ovhcloud", "oci", "all"],
+        choices=["hetzner", "aws", "ovhcloud", "oci", "gcp", "all"],
         help="Provider to update pricing for",
     )
     parser.add_argument(

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from datetime import datetime
@@ -419,65 +420,59 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
     # Compute Engine service ID
     service_name = "services/6F81-5844-456A"
 
+    # Series identifiers as they appear at the start of SKU descriptions.
+    # Listed longest-first so the regex prefers more specific matches (n2d before n2).
+    known_series = [
+        "n2d", "n4a", "c2d", "c3d", "c4a", "c4d",
+        "n1", "n2", "n4", "e2", "t2a", "t2d",
+        "c2", "c3", "c4",
+    ]
+    # Qualifiers between series and "Instance" (e.g. "C4A Arm Instance Core ...",
+    # "N2D AMD Instance Core ...", "E2 Custom Instance Core ...").
+    series_re = re.compile(
+        r"^(" + "|".join(known_series) + r")\s+(?:AMD|Arm|Custom)?\s*Instance\s+(Core|Ram)\s+running\s+in\s+",
+        re.IGNORECASE,
+    )
+    # Variants we must skip — none of these are vanilla on-demand pricing.
+    excluded_terms = (
+        "sole tenancy", "committed use", "reserved", "premium",
+        "overcommit", "dws", "extended", "memory-optimized",
+    )
+
     try:
         client = billing_v1.CloudCatalogClient()
         request = billing_v1.ListSkusRequest(parent=service_name)
 
-        # Build a map of machine type -> hourly price for the target region
-        # GCP SKU service_regions contains exact region names like "europe-west3"
-
-        # Collect per-vCPU and per-GB rates by machine series
+        # Per-series per-vCPU and per-GB hourly rates
         series_rates: dict[str, dict[str, float]] = {}
 
         for sku in client.list_skus(request=request):
-            # Only consider on-demand compute SKUs in our exact target region
             if gcp_region not in sku.service_regions:
                 continue
-
-            desc = sku.description.lower()
             category = sku.category
-
             if category.resource_family != "Compute":
                 continue
             if category.usage_type != "OnDemand":
                 continue
 
-            # Identify machine series from resource group
-            resource_group = category.resource_group.lower()
-
-            # Map resource groups to series keys
-            # Order matters: check longer prefixes first (n2d before n2, t2d before t2a)
-            series_key = None
-            if "n2d" in resource_group:
-                series_key = "n2d"
-            elif "n2" in resource_group:
-                series_key = "n2"
-            elif "e2" in resource_group:
-                series_key = "e2"
-            elif "t2d" in resource_group:
-                series_key = "t2d"
-            elif "t2a" in resource_group:
-                series_key = "t2a"
-            else:
+            desc = sku.description
+            desc_lower = desc.lower()
+            if any(term in desc_lower for term in excluded_terms):
                 continue
 
-            # Determine rate type (cpu or ram)
-            rate_type = None
-            if "core" in desc or "cpu" in desc or "vcpu" in desc:
-                rate_type = "cpu_hr"
-            elif "ram" in desc or "memory" in desc:
-                rate_type = "gb_hr"
-            else:
+            m = series_re.match(desc)
+            if not m:
                 continue
 
-            # Extract price from tiered rates (first tier)
+            series_key = m.group(1).lower()
+            rate_type = "cpu_hr" if m.group(2).lower() == "core" else "gb_hr"
+
+            # Take first non-zero tiered rate
             for tier in sku.pricing_info:
                 for rate in tier.pricing_expression.tiered_rates:
                     price = rate.unit_price.units + rate.unit_price.nanos / 1e9
                     if price > 0:
-                        if series_key not in series_rates:
-                            series_rates[series_key] = {}
-                        series_rates[series_key][rate_type] = price
+                        series_rates.setdefault(series_key, {})[rate_type] = price
                         break
                 break
 

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -424,16 +424,14 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
         request = billing_v1.ListSkusRequest(parent=service_name)
 
         # Build a map of machine type -> hourly price for the target region
-        # GCP SKU descriptions contain the machine type and region info
-        # Region mapping for SKU filtering
-        region_prefix = gcp_region.split("-")[0] + "-" + gcp_region.split("-")[1]
+        # GCP SKU service_regions contains exact region names like "europe-west3"
 
         # Collect per-vCPU and per-GB rates by machine series
         series_rates: dict[str, dict[str, float]] = {}
 
         for sku in client.list_skus(request=request):
-            # Only consider on-demand compute SKUs in our region
-            if not any(region_prefix in region for region in sku.service_regions):
+            # Only consider on-demand compute SKUs in our exact target region
+            if gcp_region not in sku.service_regions:
                 continue
 
             desc = sku.description.lower()
@@ -484,7 +482,7 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
                 break
 
         if not series_rates:
-            print(f"  [WARN] No GCP pricing rates found for region {gcp_region}")
+            print(f"  [ERROR] No GCP pricing rates found for region {gcp_region}")
             return 0
 
         print(
@@ -493,7 +491,7 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
         )
 
     except Exception as e:
-        print(f"  [WARN] Failed to fetch GCP pricing: {e}")
+        print(f"  [ERROR] Failed to fetch GCP pricing from Cloud Billing API: {e}")
         return 0
 
     # Map machine type to series key (e.g. "n2d-standard-2" -> "n2d")

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -27,3 +27,15 @@ Your API private key here (from the .pem file)
 -----END PRIVATE KEY-----
 EOT
 oci_compartment_id = "ocid1.compartment.oc1..xxx"
+
+# Google Cloud (GCP)
+# Create a service account and download JSON key from:
+# https://console.cloud.google.com/iam-admin/serviceaccounts
+gcp_project_id = "your-project-id"
+gcp_credentials = <<EOT
+{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  ...paste full JSON key here...
+}
+EOT

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,10 @@ terraform {
       source  = "oracle/oci"
       version = "~> 6.0"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
   }
 
   backend "local" {
@@ -57,6 +61,12 @@ provider "oci" {
   region       = var.cloud_provider == "oci" ? local.effective_region : "eu-frankfurt-1"
 }
 
+provider "google" {
+  project     = var.gcp_project_id
+  region      = var.cloud_provider == "gcp" ? local.effective_region : "europe-west3"
+  credentials = var.gcp_credentials != "" ? var.gcp_credentials : null
+}
+
 locals {
   config = yamldecode(file("${path.module}/../config/instances.yaml"))
 
@@ -81,6 +91,7 @@ locals {
       aws      = "eu-central-1"
       ovhcloud = "DE1"
       oci      = "eu-frankfurt-1"
+      gcp      = "europe-west3"
     },
     var.cloud_provider,
     "fsn1"
@@ -154,6 +165,21 @@ module "oci_instances" {
   labels             = merge(local.common_labels, { instance_type = each.value.id })
 }
 
+module "gcp_instances" {
+  source   = "./modules/gcp"
+  for_each = var.cloud_provider == "gcp" ? { for inst in local.instances : inst.id => inst } : {}
+
+  instance_name   = "cloud-bench-${var.cloud_provider}-${each.value.id}-${var.run_id}"
+  machine_type    = each.value.id
+  instance_arch   = lookup(local.arch_map, each.value.arch, "x86_64")
+  region          = lookup(var.instance_regions, each.value.id, local.effective_region)
+  project_id      = var.gcp_project_id
+  ssh_public_key  = local.ssh_public_key
+  allowed_ssh_ips = var.allowed_ssh_ips
+  disk_size_gb    = var.gcp_disk_size
+  labels          = merge(local.common_labels, { instance_type = replace(each.value.id, ".", "-") })
+}
+
 locals {
   all_instances = merge(
     {
@@ -176,6 +202,12 @@ locals {
     },
     {
       for inst_id, mod in module.oci_instances : inst_id => {
+        host = mod.server_ip
+        name = mod.server_name
+      }
+    },
+    {
+      for inst_id, mod in module.gcp_instances : inst_id => {
         host = mod.server_ip
         name = mod.server_name
       }

--- a/terraform/modules/gcp/cloud-init.yml.tmpl
+++ b/terraform/modules/gcp/cloud-init.yml.tmpl
@@ -1,0 +1,10 @@
+#cloud-config
+
+runcmd:
+  - mkdir -p /opt/cloud-bench
+  - chmod 755 /opt/cloud-bench
+  - sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+  - sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+final_message: "Cloud-bench instance setup complete!"

--- a/terraform/modules/gcp/data.tf
+++ b/terraform/modules/gcp/data.tf
@@ -1,0 +1,11 @@
+# Ubuntu 24.04 LTS image lookup - x86_64
+data "google_compute_image" "ubuntu_x86" {
+  family  = "ubuntu-2404-lts-amd64"
+  project = "ubuntu-os-cloud"
+}
+
+# Ubuntu 24.04 LTS image lookup - arm64
+data "google_compute_image" "ubuntu_arm64" {
+  family  = "ubuntu-2404-lts-arm64"
+  project = "ubuntu-os-cloud"
+}

--- a/terraform/modules/gcp/main.tf
+++ b/terraform/modules/gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "~> 7.1"
     }
   }
 }
@@ -14,7 +14,7 @@ locals {
     ssh_public_key = var.ssh_public_key
   })
 
-  zone = "${var.region}-a"
+  zone = var.zone != "" ? var.zone : "${var.region}-${var.zone_suffix}"
 }
 
 # --- Networking ---

--- a/terraform/modules/gcp/main.tf
+++ b/terraform/modules/gcp/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+
+locals {
+  image = var.instance_arch == "arm64" ? data.google_compute_image.ubuntu_arm64.self_link : data.google_compute_image.ubuntu_x86.self_link
+
+  cloud_init = templatefile("${path.module}/cloud-init.yml.tmpl", {
+    ssh_public_key = var.ssh_public_key
+  })
+
+  zone = "${var.region}-a"
+}
+
+# --- Networking ---
+
+resource "google_compute_firewall" "benchmark_ssh" {
+  name    = "${var.instance_name}-allow-ssh"
+  network = "default"
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = var.allowed_ssh_ips
+  target_tags   = ["cloud-bench-${var.labels["run_id"]}"]
+}
+
+# --- Compute Instance ---
+
+resource "google_compute_instance" "benchmark" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+  zone         = local.zone
+  project      = var.project_id
+
+  tags = ["cloud-bench-${var.labels["run_id"]}"]
+
+  labels = var.labels
+
+  boot_disk {
+    initialize_params {
+      image = local.image
+      size  = var.disk_size_gb
+      type  = var.disk_type
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      # Ephemeral public IP
+    }
+  }
+
+  metadata = {
+    ssh-keys  = "ubuntu:${var.ssh_public_key}"
+    user-data = local.cloud_init
+  }
+
+  scheduling {
+    automatic_restart   = false
+    on_host_maintenance = "TERMINATE"
+    preemptible         = false
+  }
+}

--- a/terraform/modules/gcp/main.tf
+++ b/terraform/modules/gcp/main.tf
@@ -70,7 +70,7 @@ resource "google_compute_instance" "benchmark" {
 
   scheduling {
     automatic_restart   = false
-    on_host_maintenance = "TERMINATE"
+    on_host_maintenance = "MIGRATE"
     preemptible         = false
   }
 }

--- a/terraform/modules/gcp/main.tf
+++ b/terraform/modules/gcp/main.tf
@@ -13,6 +13,10 @@ locals {
   cloud_init = templatefile("${path.module}/cloud-init.yml.tmpl", {})
 
   zone = var.zone != "" ? var.zone : "${var.region}-${var.zone_suffix}"
+
+  # 4th-gen+ families (C4, C4A, C4D, N4, N4A) require hyperdisk; older families use pd-* disks
+  needs_hyperdisk     = can(regex("^(c4|c4a|c4d|n4|n4a)-", var.machine_type))
+  effective_disk_type = local.needs_hyperdisk ? "hyperdisk-balanced" : var.disk_type
 }
 
 # --- Networking ---
@@ -51,7 +55,7 @@ resource "google_compute_instance" "benchmark" {
     initialize_params {
       image = local.image
       size  = var.disk_size_gb
-      type  = var.disk_type
+      type  = local.effective_disk_type
     }
   }
 

--- a/terraform/modules/gcp/main.tf
+++ b/terraform/modules/gcp/main.tf
@@ -10,9 +10,7 @@ terraform {
 locals {
   image = var.instance_arch == "arm64" ? data.google_compute_image.ubuntu_arm64.self_link : data.google_compute_image.ubuntu_x86.self_link
 
-  cloud_init = templatefile("${path.module}/cloud-init.yml.tmpl", {
-    ssh_public_key = var.ssh_public_key
-  })
+  cloud_init = templatefile("${path.module}/cloud-init.yml.tmpl", {})
 
   zone = var.zone != "" ? var.zone : "${var.region}-${var.zone_suffix}"
 }

--- a/terraform/modules/gcp/outputs.tf
+++ b/terraform/modules/gcp/outputs.tf
@@ -12,3 +12,8 @@ output "instance_id" {
   description = "GCP instance ID"
   value       = google_compute_instance.benchmark.instance_id
 }
+
+output "zone" {
+  description = "GCP zone where the instance is deployed"
+  value       = google_compute_instance.benchmark.zone
+}

--- a/terraform/modules/gcp/outputs.tf
+++ b/terraform/modules/gcp/outputs.tf
@@ -1,0 +1,14 @@
+output "server_ip" {
+  description = "Public IP address of the instance"
+  value       = google_compute_instance.benchmark.network_interface[0].access_config[0].nat_ip
+}
+
+output "server_name" {
+  description = "Name of the instance"
+  value       = var.instance_name
+}
+
+output "instance_id" {
+  description = "GCP instance ID"
+  value       = google_compute_instance.benchmark.instance_id
+}

--- a/terraform/modules/gcp/variables.tf
+++ b/terraform/modules/gcp/variables.tf
@@ -1,0 +1,63 @@
+variable "instance_name" {
+  description = "Name for the GCP compute instance"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "GCP machine type (e.g. e2-medium, n2-standard-2)"
+  type        = string
+}
+
+variable "instance_arch" {
+  description = "Instance architecture: x86_64 or arm64"
+  type        = string
+  default     = "x86_64"
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.instance_arch)
+    error_message = "instance_arch must be x86_64 or arm64"
+  }
+}
+
+variable "region" {
+  description = "GCP region (e.g. europe-west3)"
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content"
+  type        = string
+}
+
+variable "allowed_ssh_ips" {
+  description = "CIDR blocks allowed SSH access"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.allowed_ssh_ips) > 0
+    error_message = "At least one allowed SSH IP must be specified"
+  }
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "disk_type" {
+  description = "Boot disk type (pd-balanced, pd-ssd, pd-standard)"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "labels" {
+  description = "Labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gcp/variables.tf
+++ b/terraform/modules/gcp/variables.tf
@@ -68,8 +68,8 @@ variable "disk_type" {
   default     = "pd-balanced"
 
   validation {
-    condition     = contains(["pd-balanced", "pd-ssd", "pd-standard", "pd-extreme", "pd-hyperdisk-balanced", "pd-hyperdisk-extreme"], var.disk_type)
-    error_message = "disk_type must be one of: pd-balanced, pd-ssd, pd-standard, pd-extreme, pd-hyperdisk-balanced, pd-hyperdisk-extreme"
+    condition     = contains(["pd-balanced", "pd-ssd", "pd-standard", "pd-extreme", "hyperdisk-balanced", "hyperdisk-extreme", "hyperdisk-throughput"], var.disk_type)
+    error_message = "disk_type must be one of: pd-balanced, pd-ssd, pd-standard, pd-extreme, hyperdisk-balanced, hyperdisk-extreme, hyperdisk-throughput. For C4/C4A/C4D/N4/N4A families, hyperdisk is auto-selected regardless."
   }
 }
 

--- a/terraform/modules/gcp/variables.tf
+++ b/terraform/modules/gcp/variables.tf
@@ -24,6 +24,18 @@ variable "region" {
   type        = string
 }
 
+variable "zone_suffix" {
+  description = "Zone suffix to append to region (e.g., 'a' creates zone 'europe-west3-a')"
+  type        = string
+  default     = "a"
+}
+
+variable "zone" {
+  description = "Full GCP zone (e.g. europe-west3-a). Overrides region and zone_suffix if set"
+  type        = string
+  default     = ""
+}
+
 variable "project_id" {
   description = "GCP project ID"
   type        = string
@@ -54,6 +66,11 @@ variable "disk_type" {
   description = "Boot disk type (pd-balanced, pd-ssd, pd-standard)"
   type        = string
   default     = "pd-balanced"
+
+  validation {
+    condition     = contains(["pd-balanced", "pd-ssd", "pd-standard", "pd-extreme", "pd-hyperdisk-balanced", "pd-hyperdisk-extreme"], var.disk_type)
+    error_message = "disk_type must be one of: pd-balanced, pd-ssd, pd-standard, pd-extreme, pd-hyperdisk-balanced, pd-hyperdisk-extreme"
+  }
 }
 
 variable "labels" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -160,6 +160,7 @@ variable "oci_compartment_id" {
 variable "gcp_project_id" {
   description = "Google Cloud project ID"
   type        = string
+  sensitive   = true
   default     = ""
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,8 +20,8 @@ variable "cloud_provider" {
   default     = "hetzner"
 
   validation {
-    condition     = can(regex("^(hetzner|aws|ovhcloud|oci)$", var.cloud_provider))
-    error_message = "Provider must be 'hetzner', 'aws', 'ovhcloud', or 'oci'."
+    condition     = can(regex("^(hetzner|aws|ovhcloud|oci|gcp)$", var.cloud_provider))
+    error_message = "Provider must be 'hetzner', 'aws', 'ovhcloud', 'oci', or 'gcp'."
   }
 }
 
@@ -155,4 +155,23 @@ variable "oci_compartment_id" {
   type        = string
   sensitive   = true
   default     = ""
+}
+
+variable "gcp_project_id" {
+  description = "Google Cloud project ID"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_credentials" {
+  description = "Google Cloud service account JSON key content"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "gcp_disk_size" {
+  description = "Boot disk size in GB for GCP instances"
+  type        = number
+  default     = 20
 }


### PR DESCRIPTION
## What changed

Adds Google Cloud Platform (GCP) as a 5th provider alongside Hetzner, AWS, OVHcloud, and OCI.

## Provider support

- Terraform module for Compute Engine (firewall + instance, ephemeral public IP, hyperdisk auto-selected for c4/c4a/c4d/n4/n4a families)
- CI workflows: provision/benchmark/destroy and orphan cleanup
- `scripts/run-local.sh`: gcp case (region, credentials, tf vars)
- `scripts/update_pricing.py`: GCP Cloud Billing Catalog API integration
- Setup guide: project, service account, secrets

## Instance config (Frankfurt / europe-west3)

- e2-standard-2 — mixed silicon, baseline
- n2-standard-2 — Intel Cascade/Ice Lake
- n2d-standard-2 — AMD EPYC Rome
- t2d-standard-2 — AMD EPYC Milan
- c4a-standard-2 — Ampere Axion ARM

## Security

- Firewall scoped to runner IP/32
- Service account uses Compute Admin scoped to a single project
- Cleanup workflow terminates orphans older than 2h

## Tested

End-to-end provision + sysbench benchmark + destroy verified locally on all 4 active shapes (e2/n2/t2d/c4a).