### PR TITLE
feat: add GCP and Azure provider support

### DIFF
--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -116,7 +116,7 @@ jobs:
             region: europe-west3
             instances: all
           - provider: azure
-            region: westeurope
+            region: germanywestcentral
             instances: all
     steps:
       - uses: actions/checkout@v6
@@ -444,7 +444,7 @@ jobs:
           fi
 
           # Region mapping (must match matrix above)
-          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 [azure]=westeurope )
+          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 [azure]=germanywestcentral )
 
           # Process each provider's results
           for provider in hetzner aws ovhcloud oci gcp azure; do

--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -116,7 +116,7 @@ jobs:
             region: europe-west3
             instances: all
           - provider: azure
-            region: germanywestcentral
+            region: northeurope
             instances: all
     steps:
       - uses: actions/checkout@v6
@@ -444,7 +444,7 @@ jobs:
           fi
 
           # Region mapping (must match matrix above)
-          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 [azure]=germanywestcentral )
+          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 [azure]=northeurope )
 
           # Process each provider's results
           for provider in hetzner aws ovhcloud oci gcp azure; do

--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -55,6 +55,7 @@ jobs:
               ('ovhcloud', 'EUR'),
               ('oci', 'USD'),
               ('gcp', 'USD'),
+              ('azure', 'USD'),
           ]
 
           summary = "## Cost Estimate\n\n"
@@ -113,6 +114,9 @@ jobs:
             instances: all
           - provider: gcp
             region: europe-west3
+            instances: all
+          - provider: azure
+            region: westeurope
             instances: all
     steps:
       - uses: actions/checkout@v6
@@ -197,6 +201,10 @@ jobs:
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
           TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
           TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
+          TF_VAR_azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          TF_VAR_azure_client_id: ${{ secrets.AZURE_CLIENT_ID || '' }}
+          TF_VAR_azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET || '' }}
+          TF_VAR_azure_tenant_id: ${{ secrets.AZURE_TENANT_ID || '' }}
         run: |
           terraform apply -auto-approve \
             -var="run_id=${{ github.run_id }}-${{ matrix.provider }}" \
@@ -277,6 +285,10 @@ jobs:
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
           TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
           TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
+          TF_VAR_azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          TF_VAR_azure_client_id: ${{ secrets.AZURE_CLIENT_ID || '' }}
+          TF_VAR_azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET || '' }}
+          TF_VAR_azure_tenant_id: ${{ secrets.AZURE_TENANT_ID || '' }}
         run: |
           terraform destroy -auto-approve \
             -var="run_id=${{ github.run_id }}-${{ matrix.provider }}" \
@@ -371,6 +383,18 @@ jobs:
             else
               echo "[OK] GCP resources cleaned up successfully"
             fi
+
+          elif [ "${{ matrix.provider }}" = "azure" ]; then
+            cd terraform
+            REMAINING=$(terraform state list 2>/dev/null | grep -c "azurerm_linux_virtual_machine" || true)
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "::error::CRITICAL: Azure VMs still in Terraform state after cleanup!"
+              terraform state list | grep "azurerm_linux_virtual_machine"
+              echo "Manual intervention required!"
+              exit 1
+            else
+              echo "[OK] Azure resources cleaned up successfully"
+            fi
           fi
 
   # Serialize access to benchmark-data branch to prevent race conditions
@@ -420,10 +444,10 @@ jobs:
           fi
 
           # Region mapping (must match matrix above)
-          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 )
+          declare -A REGIONS=( [hetzner]=fsn1 [aws]=eu-central-1 [ovhcloud]=DE1 [oci]=eu-frankfurt-1 [gcp]=europe-west3 [azure]=westeurope )
 
           # Process each provider's results
-          for provider in hetzner aws ovhcloud oci gcp; do
+          for provider in hetzner aws ovhcloud oci gcp azure; do
             PROVIDER_DIR="artifacts/results-$provider"
             if [ -d "$PROVIDER_DIR" ]; then
               REGION="${REGIONS[$provider]}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ on:
           - ovhcloud
           - oci
           - gcp
+          - azure
 
       instances:
         description: 'Instance IDs (comma-separated, or "all")'
@@ -79,6 +80,7 @@ jobs:
               ovhcloud) REGION="DE1" ;;
               oci)      REGION="eu-frankfurt-1" ;;
               gcp)      REGION="europe-west3" ;;
+              azure)    REGION="westeurope" ;;
             esac
           fi
           echo "region=$REGION" >> $GITHUB_OUTPUT
@@ -112,6 +114,14 @@ jobs:
           GCP_PROJECT_SET="${{ secrets.GCP_PROJECT_ID != '' }}"
           if [ "${{ github.event.inputs.provider }}" = "gcp" ] && { [ "$GCP_KEY_SET" != "true" ] || [ "$GCP_PROJECT_SET" != "true" ]; }; then
             echo "::error::GCP_CREDENTIALS and GCP_PROJECT_ID secrets are required for GCP"
+            exit 1
+          fi
+          AZURE_SUB_SET="${{ secrets.AZURE_SUBSCRIPTION_ID != '' }}"
+          AZURE_CLIENT_SET="${{ secrets.AZURE_CLIENT_ID != '' }}"
+          AZURE_SECRET_SET="${{ secrets.AZURE_CLIENT_SECRET != '' }}"
+          AZURE_TENANT_SET="${{ secrets.AZURE_TENANT_ID != '' }}"
+          if [ "${{ github.event.inputs.provider }}" = "azure" ] && { [ "$AZURE_SUB_SET" != "true" ] || [ "$AZURE_CLIENT_SET" != "true" ] || [ "$AZURE_SECRET_SET" != "true" ] || [ "$AZURE_TENANT_SET" != "true" ]; }; then
+            echo "::error::AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID secrets are required for Azure"
             exit 1
           fi
           if [ -n "$INSTANCE_REGIONS" ] && [ "$INSTANCE_REGIONS" != "{}" ]; then
@@ -198,6 +208,10 @@ jobs:
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
           TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
           TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
+          TF_VAR_azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          TF_VAR_azure_client_id: ${{ secrets.AZURE_CLIENT_ID || '' }}
+          TF_VAR_azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET || '' }}
+          TF_VAR_azure_tenant_id: ${{ secrets.AZURE_TENANT_ID || '' }}
         run: |
           terraform apply -auto-approve \
             -var="run_id=${{ env.RUN_ID }}" \
@@ -284,6 +298,57 @@ jobs:
             aws ec2 authorize-security-group-ingress --group-id "$sg" \
               --protocol icmp --port -1 --cidr "$RUNNER_IP/32" || true
           done
+
+      - name: Update Azure NSG with Runner IP
+        if: ${{ github.event.inputs.provider == 'azure' }}
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        run: |
+          RUNNER_IP=$(curl -s --retry 3 https://ifconfig.me || curl -s --retry 3 https://api.ipify.org)
+          echo "Benchmark runner IP: $RUNNER_IP"
+          PREV_IP="${{ needs.provision.outputs.runner_ip }}"
+          echo "Provision runner IP: $PREV_IP"
+          if [ "$RUNNER_IP" = "$PREV_IP" ]; then
+            echo "Same IP, no update needed"
+            exit 0
+          fi
+
+          az login --service-principal \
+            -u "$AZURE_CLIENT_ID" \
+            -p "$AZURE_CLIENT_SECRET" \
+            --tenant "$AZURE_TENANT_ID" \
+            --output none
+          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+          # Find all NSGs tagged with our run_id
+          NSG_LIST=$(az network nsg list \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --query "[?tags.run_id=='${{ env.RUN_ID }}' && tags.project=='cloud-bench'].{name:name, rg:resourceGroup}" \
+            -o tsv)
+
+          if [ -z "$NSG_LIST" ]; then
+            echo "No matching NSGs found"
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r nsg_name rg_name; do
+            echo "Updating NSG: $nsg_name in $rg_name"
+            EXISTING=$(az network nsg rule show \
+              --nsg-name "$nsg_name" -g "$rg_name" -n allow-ssh \
+              --query "sourceAddressPrefixes" -o tsv 2>/dev/null || echo "")
+            NEW_IP="${RUNNER_IP}/32"
+            if echo "$EXISTING" | grep -q "$NEW_IP"; then
+              echo "  IP already in NSG rule, skipping"
+              continue
+            fi
+            UPDATED="${EXISTING} ${NEW_IP}"
+            az network nsg rule update \
+              --nsg-name "$nsg_name" -g "$rg_name" -n allow-ssh \
+              --source-address-prefixes $UPDATED || true
+          done <<< "$NSG_LIST"
 
       - name: Setup gcloud CLI
         if: ${{ github.event.inputs.provider == 'gcp' }}
@@ -632,6 +697,10 @@ jobs:
           TF_VAR_oci_compartment_id: ${{ secrets.OCI_COMPARTMENT_ID || 'unused' }}
           TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID || 'unused' }}
           TF_VAR_gcp_credentials: ${{ secrets.GCP_CREDENTIALS || '' }}
+          TF_VAR_azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          TF_VAR_azure_client_id: ${{ secrets.AZURE_CLIENT_ID || '' }}
+          TF_VAR_azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET || '' }}
+          TF_VAR_azure_tenant_id: ${{ secrets.AZURE_TENANT_ID || '' }}
         run: |
           terraform destroy -auto-approve \
             -var="run_id=${{ env.RUN_ID }}" \
@@ -733,6 +802,18 @@ jobs:
               exit 1
             else
               echo "[OK] GCP resources cleaned up successfully"
+            fi
+
+          elif [ "${{ github.event.inputs.provider }}" = "azure" ]; then
+            cd terraform
+            REMAINING=$(terraform state list 2>/dev/null | grep -c "azurerm_linux_virtual_machine" || true)
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "::error::CRITICAL: Azure VMs still in Terraform state after cleanup!"
+              terraform state list | grep "azurerm_linux_virtual_machine"
+              echo "Manual intervention required!"
+              exit 1
+            else
+              echo "[OK] Azure resources cleaned up successfully"
             fi
           fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -285,16 +285,19 @@ jobs:
               --protocol icmp --port -1 --cidr "$RUNNER_IP/32" || true
           done
 
+      - name: Authenticate to GCP
+        if: ${{ github.event.inputs.provider == 'gcp' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
       - name: Setup gcloud CLI
         if: ${{ github.event.inputs.provider == 'gcp' }}
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Update GCP Firewall Rules with Runner IP
         if: ${{ github.event.inputs.provider == 'gcp' }}
         env:
-          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           RUNNER_IP=$(curl -s --retry 3 https://ifconfig.me || curl -s --retry 3 https://api.ipify.org)
@@ -306,34 +309,29 @@ jobs:
             exit 0
           fi
 
-          # Write credentials to temp file for gcloud auth
-          trap 'rm -f /tmp/gcp-key.json' EXIT
-          echo "$GCP_CREDENTIALS" > /tmp/gcp-key.json
-          chmod 600 /tmp/gcp-key.json
-          gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
-          gcloud config set project "$GCP_PROJECT_ID"
-
-          # Find cloud-bench firewall rules for this run and add the new IP
-          RULES=$(gcloud compute firewall-rules list --filter="name~cloud-bench.*${{ env.RUN_ID }}" --format="value(name)")
+          RULES=$(gcloud compute firewall-rules list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="name~cloud-bench.*${{ env.RUN_ID }}" \
+            --format="value(name)")
           for rule in $RULES; do
             echo "Updating firewall rule: $rule"
-            EXISTING=$(gcloud compute firewall-rules describe "$rule" --format="value(sourceRanges)")
+            EXISTING=$(gcloud compute firewall-rules describe "$rule" \
+              --project="$GCP_PROJECT_ID" \
+              --format="value(sourceRanges)")
             NEW_IP="${RUNNER_IP}/32"
-            # Check if IP already exists to avoid duplicates
             if echo "$EXISTING" | grep -q "${NEW_IP}"; then
               echo "IP ${NEW_IP} already in source ranges, skipping update"
               continue
             fi
-            # Handle empty existing ranges
             if [ -z "$EXISTING" ]; then
               UPDATED_RANGES="$NEW_IP"
             else
               UPDATED_RANGES="${EXISTING},${NEW_IP}"
             fi
             gcloud compute firewall-rules update "$rule" \
+              --project="$GCP_PROJECT_ID" \
               --source-ranges="$UPDATED_RANGES" || true
           done
-          rm -f /tmp/gcp-key.json
 
       - name: Update OCI Security Lists with Runner IP
         if: ${{ github.event.inputs.provider == 'oci' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,7 +80,7 @@ jobs:
               ovhcloud) REGION="DE1" ;;
               oci)      REGION="eu-frankfurt-1" ;;
               gcp)      REGION="europe-west3" ;;
-              azure)    REGION="westeurope" ;;
+              azure)    REGION="germanywestcentral" ;;
             esac
           fi
           echo "region=$REGION" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,7 +80,7 @@ jobs:
               ovhcloud) REGION="DE1" ;;
               oci)      REGION="eu-frankfurt-1" ;;
               gcp)      REGION="europe-west3" ;;
-              azure)    REGION="germanywestcentral" ;;
+              azure)    REGION="northeurope" ;;
             esac
           fi
           echo "region=$REGION" >> $GITHUB_OUTPUT

--- a/.github/workflows/cleanup/cleanup-azure.yml
+++ b/.github/workflows/cleanup/cleanup-azure.yml
@@ -1,0 +1,72 @@
+name: Cleanup Azure Orphans
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: |
+            {
+              "clientId": "${{ secrets.AZURE_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}",
+              "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}",
+              "tenantId": "${{ secrets.AZURE_TENANT_ID }}"
+            }
+
+      - name: Find and delete orphaned resource groups
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          if [ -z "$AZURE_SUBSCRIPTION_ID" ]; then
+            echo "Azure credentials not configured, skipping"
+            exit 0
+          fi
+
+          echo "Checking for orphaned cloud-bench resource groups..."
+
+          # Resource groups are named cloud-bench-azure-<instance>-<run_id>
+          RG_LIST=$(az group list \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --query "[?tags.project=='cloud-bench'].{name:name, created:tags.run_id, time:tags.run_id}" \
+            -o tsv)
+
+          if [ -z "$RG_LIST" ]; then
+            echo "[OK] No cloud-bench resource groups found"
+            exit 0
+          fi
+
+          echo "Found resource groups:"
+          echo "$RG_LIST"
+
+          CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%S)
+          DELETED=0
+
+          while IFS=$'\t' read -r rg_name run_id _; do
+            # Get the VM creation time from the resource group
+            CREATED=$(az group show -n "$rg_name" --query "properties.provisioningStateTransitionTime" -o tsv 2>/dev/null || echo "")
+            if [ -z "$CREATED" ]; then
+              echo "Could not determine creation time for $rg_name, skipping"
+              continue
+            fi
+            if [[ "$CREATED" < "$CUTOFF" ]]; then
+              echo "Deleting orphaned resource group: $rg_name (created: $CREATED, run_id: $run_id)"
+              az group delete -n "$rg_name" --yes --no-wait
+              DELETED=$((DELETED + 1))
+            else
+              echo "Keeping recent resource group: $rg_name (created: $CREATED)"
+            fi
+          done <<< "$RG_LIST"
+
+          echo ""
+          echo "Summary: Queued deletion of $DELETED orphaned resource group(s)"
+
+          if [ $DELETED -gt 0 ]; then
+            echo "## Azure Orphan Cleanup" >> $GITHUB_STEP_SUMMARY
+            echo "Queued deletion of **$DELETED** orphaned resource group(s) older than 2 hours." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/fabianwimberger/cloud-bench/branch/main/graph/badge.svg)](https://codecov.io/gh/fabianwimberger/cloud-bench)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 28 instance types across Hetzner Cloud, AWS EC2, OVHcloud, Oracle Cloud (OCI), and Google Cloud Platform (GCP).
+A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 31 instance types across Hetzner Cloud, AWS EC2, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP), and Microsoft Azure.
 
 ## Background
 
@@ -12,7 +12,7 @@ A €20 instance can mean very different things between providers. This runs the
 
 ## Features
 
-- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI, GCP (28 instance types)
+- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI, GCP, Azure (31 instance types)
 - **Standardized benchmarks** — CPU (sysbench), Memory (sysbench), Disk I/O (fio)
 - **Metric averaging** — scores based on all historical runs, not just the latest
 - **Cost analysis** — performance per dollar with EUR/USD toggle
@@ -79,6 +79,13 @@ PROVIDER=ovhcloud ./scripts/run-local.sh
 export GCP_PROJECT_ID="your-project-id"
 export GCP_CREDENTIALS='{"type": "service_account", ...}'  # Service account JSON key
 PROVIDER=gcp ./scripts/run-local.sh
+
+# Azure
+export AZURE_SUBSCRIPTION_ID="your-subscription-id"
+export AZURE_CLIENT_ID="your-client-id"
+export AZURE_CLIENT_SECRET="your-client-secret"
+export AZURE_TENANT_ID="your-tenant-id"
+PROVIDER=azure ./scripts/run-local.sh
 
 # Or run via GitHub Actions: Actions > Run Benchmarks
 ```

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -293,10 +293,10 @@ providers:
         monthly: 76.3
   azure:
     currency: USD
-    default_region: westeurope
+    default_region: germanywestcentral
     regions:
-      westeurope:
-        name: Amsterdam
+      germanywestcentral:
+        name: Frankfurt
     instances:
     - id: Standard_B2s
       name: B2s
@@ -305,8 +305,8 @@ providers:
       ram_gb: 4
       disk_gb: 30
       pricing:
-        hourly: 0.0416
-        monthly: 29.95
+        hourly: 0.048
+        monthly: 34.56
     - id: Standard_D2s_v5
       name: D2s v5
       arch: X86
@@ -314,17 +314,8 @@ providers:
       ram_gb: 8
       disk_gb: 30
       pricing:
-        hourly: 0.096
-        monthly: 69.12
-    - id: Standard_F2s_v2
-      name: F2s v2
-      arch: X86
-      vcpu: 2
-      ram_gb: 4
-      disk_gb: 30
-      pricing:
-        hourly: 0.099
-        monthly: 71.28
+        hourly: 0.115
+        monthly: 82.8
     - id: Standard_D2ps_v5
       name: D2ps v5
       arch: ARM64
@@ -332,14 +323,14 @@ providers:
       ram_gb: 8
       disk_gb: 30
       pricing:
-        hourly: 0.077
-        monthly: 55.44
+        hourly: 0.092
+        monthly: 66.24
 exchange_rates:
   eur_to_usd: 1.1702
   usd_to_eur: 0.8546
   last_updated: '2026-04-30'
   source: Frankfurter API (ECB data)
 _metadata:
-  last_pricing_update: '2026-05-02T09:39:29.757001'
+  last_pricing_update: '2026-05-02T23:15:37.026915'
   source: Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing
-    API / GCP Cloud Billing API
+    API / GCP Cloud Billing API / Azure Retail Prices API

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -293,38 +293,29 @@ providers:
         monthly: 76.3
   azure:
     currency: USD
-    default_region: germanywestcentral
+    default_region: northeurope
     regions:
-      germanywestcentral:
-        name: Frankfurt
+      northeurope:
+        name: Dublin
     instances:
-    - id: Standard_B2s
-      name: B2s
-      arch: X86
-      vcpu: 2
-      ram_gb: 4
-      disk_gb: 30
-      pricing:
-        hourly: 0.048
-        monthly: 34.56
-    - id: Standard_D2s_v5
-      name: D2s v5
+    - id: Standard_D2as_v7
+      name: D2as v7
       arch: X86
       vcpu: 2
       ram_gb: 8
       disk_gb: 30
       pricing:
-        hourly: 0.115
-        monthly: 82.8
-    - id: Standard_D2ps_v5
-      name: D2ps v5
+        hourly: 0.101
+        monthly: 73.73
+    - id: Standard_D2ps_v6
+      name: D2ps v6
       arch: ARM64
       vcpu: 2
       ram_gb: 8
       disk_gb: 30
       pricing:
-        hourly: 0.092
-        monthly: 66.24
+        hourly: 0.0784
+        monthly: 57.23
 exchange_rates:
   eur_to_usd: 1.1702
   usd_to_eur: 0.8546

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -291,6 +291,49 @@ providers:
       pricing:
         hourly: 0.10597
         monthly: 76.3
+  azure:
+    currency: USD
+    default_region: westeurope
+    regions:
+      westeurope:
+        name: Amsterdam
+    instances:
+    - id: Standard_B2s
+      name: B2s
+      arch: X86
+      vcpu: 2
+      ram_gb: 4
+      disk_gb: 30
+      pricing:
+        hourly: 0.0416
+        monthly: 29.95
+    - id: Standard_D2s_v5
+      name: D2s v5
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 30
+      pricing:
+        hourly: 0.096
+        monthly: 69.12
+    - id: Standard_F2s_v2
+      name: F2s v2
+      arch: X86
+      vcpu: 2
+      ram_gb: 4
+      disk_gb: 30
+      pricing:
+        hourly: 0.099
+        monthly: 71.28
+    - id: Standard_D2ps_v5
+      name: D2ps v5
+      arch: ARM64
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 30
+      pricing:
+        hourly: 0.077
+        monthly: 55.44
 exchange_rates:
   eur_to_usd: 1.1702
   usd_to_eur: 0.8546

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,8 @@ config/instances.yaml            # Single source of truth for instances & pricin
 │  modules/aws/              │   EC2 instances, security groups, key pairs
 │  modules/ovhcloud/         │   OpenStack instances, key pairs (no security groups)
 │  modules/oci/              │   OCI instances, VCN, subnets, security lists
+│  modules/gcp/              │   GCE instances, firewall rules, service accounts
+│  modules/azure/            │   VMs, resource groups, NSGs, public IPs
 └────────────┬──────────────┘
              ▼
 ┌── Ansible ────────────────┐
@@ -87,13 +89,13 @@ See [data-format.md](data-format.md) for full schemas.
 ## Security
 
 - Fresh Ed25519 SSH key generated per run, never reused
-- Firewall/security group allows SSH from runner IP only (Hetzner, AWS, OCI)
+- Firewall/security group/NSG allows SSH from runner IP only (Hetzner, AWS, OCI, GCP, Azure)
 - OVHcloud does not support security groups — SSH key auth only
 - `if: always()` cleanup in CI ensures infrastructure destruction
 - Verify Cleanup step confirms resources are gone via provider APIs after destroy
 - Provider secrets passed via `TF_VAR_` environment variables, never on command line
 - Orphan cleanup workflows: manual trigger (all providers)
-- Dedicated project/IAM user/OpenStack user/compartment recommended for isolation
+- Dedicated project/IAM user/OpenStack user/compartment/service principal recommended for isolation
 
 ## Workflows
 
@@ -109,3 +111,5 @@ See [data-format.md](data-format.md) for full schemas.
 | `cleanup-aws.yml` | Manual | Terminate orphaned AWS instances older than 2 hours |
 | `cleanup-ovhcloud.yml` | Manual | Terminate orphaned OVHcloud instances older than 2 hours |
 | `cleanup-oci.yml` | Manual | Terminate orphaned OCI instances older than 2 hours |
+| `cleanup-gcp.yml` | Manual | Delete orphaned GCP instances older than 2 hours |
+| `cleanup-azure.yml` | Manual | Delete orphaned Azure resource groups older than 2 hours |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ exchange_rates:
 | OVHcloud | EUR | DE1 (Frankfurt) | 5 (d2-4, b3-8, c3-4, c3-8, r3-16) |
 | OCI      | USD | eu-frankfurt-1 (Frankfurt) | 3 (e5-flex-1-4, std3-flex-1-4, a2-flex-2-4) |
 | GCP      | USD | europe-west3 (Frankfurt) | 5 (e2-standard-2, n2-standard-2, n2d-standard-2, t2d-standard-2, c4a-standard-2) |
-| Azure    | USD | germanywestcentral (Frankfurt) | 3 (Standard_B2s, Standard_D2s_v5, Standard_D2ps_v5) |
+| Azure    | USD | northeurope (Dublin) | 2 (Standard_D2as_v7, Standard_D2ps_v6) |
 
 ## Adding Instances
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,8 @@ exchange_rates:
 | AWS      | USD | eu-central-1 (Frankfurt) | 6 (t3.micro, t3.small, t4g.micro, t4g.small, c7i-flex.large, m7i-flex.large) |
 | OVHcloud | EUR | DE1 (Frankfurt) | 5 (d2-4, b3-8, c3-4, c3-8, r3-16) |
 | OCI      | USD | eu-frankfurt-1 (Frankfurt) | 3 (e5-flex-1-4, std3-flex-1-4, a2-flex-2-4) |
+| GCP      | USD | europe-west3 (Frankfurt) | 5 (e2-standard-2, n2-standard-2, n2d-standard-2, t2d-standard-2, c4a-standard-2) |
+| Azure    | USD | westeurope (Amsterdam) | 4 (Standard_B2s, Standard_D2s_v5, Standard_F2s_v2, Standard_D2ps_v5) |
 
 ## Adding Instances
 
@@ -129,6 +131,8 @@ APIs used:
 - **AWS**: `api.pricing.us-east-1.amazonaws.com` (requires AWS credentials)
 - **OVHcloud**: `api.ovh.com/v1/order/catalog/public/cloud` (public, no auth)
 - **OCI**: `apex.oracle.com/pricing` (public, no auth, via APEX API)
+- **GCP**: Cloud Billing API (requires GCP credentials with `billing.resourceCosts.get`)
+- **Azure**: `prices.azure.com/api/retail/prices` (public, no auth)
 - **Exchange rates**: Frankfurter API (ECB data)
 
 ## Validation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ exchange_rates:
 | OVHcloud | EUR | DE1 (Frankfurt) | 5 (d2-4, b3-8, c3-4, c3-8, r3-16) |
 | OCI      | USD | eu-frankfurt-1 (Frankfurt) | 3 (e5-flex-1-4, std3-flex-1-4, a2-flex-2-4) |
 | GCP      | USD | europe-west3 (Frankfurt) | 5 (e2-standard-2, n2-standard-2, n2d-standard-2, t2d-standard-2, c4a-standard-2) |
-| Azure    | USD | westeurope (Amsterdam) | 4 (Standard_B2s, Standard_D2s_v5, Standard_F2s_v2, Standard_D2ps_v5) |
+| Azure    | USD | germanywestcentral (Frankfurt) | 3 (Standard_B2s, Standard_D2s_v5, Standard_D2ps_v5) |
 
 ## Adding Instances
 

--- a/docs/cost-analysis.md
+++ b/docs/cost-analysis.md
@@ -47,6 +47,6 @@ If cleanup fails and instances keep running, the maximum hourly cost is the sum 
 |---|---------|-----|----------|-----|-----|-------|
 | Pricing | Simple, flat hourly/monthly | On-demand, region-dependent | Hourly consumption billing | Pay-as-you-go | Per-second billing | Per-minute billing |
 | Hidden fees | None | Egress, EBS IOPS (minimal for benchmarks) | None | Egress | Egress | Egress |
-| Cheapest instance | €2.99/mo (CX23) | $6.91/mo (t4g.micro) | €14.26/mo (D2-4) | Free tier eligible | $64.19/mo (e2-standard-2) | $29.95/mo (Standard_B2s) |
+| Cheapest instance | €2.99/mo (CX23) | $6.91/mo (t4g.micro) | €14.26/mo (D2-4) | Free tier eligible | $64.19/mo (e2-standard-2) | $61.17/mo (Standard_D2ps_v6) |
 | Cleanup | hcloud CLI / scheduled workflow | AWS CLI / scheduled workflow | OpenStack CLI / manual workflow | OCI CLI / manual workflow | gcloud CLI / scheduled workflow | az CLI / scheduled workflow |
 | Billing granularity | Hourly | Per-second | Hourly | Per-second | Per-second | Per-minute |

--- a/docs/cost-analysis.md
+++ b/docs/cost-analysis.md
@@ -10,6 +10,8 @@ A benchmark run provisions all configured instances for a single provider for ~1
 | AWS      | 6         | ~$0.15      |
 | OVHcloud | 5         | ~€0.15      |
 | OCI      | 3         | ~$0.10      |
+| GCP      | 5         | ~$0.15      |
+| Azure    | 4         | ~$0.10      |
 
 Exact cost depends on which instances are configured in `config/instances.yaml`. The cost-guard workflow estimates this before each run and blocks anything over $5 or 15 instances.
 
@@ -23,6 +25,8 @@ If cleanup fails and instances keep running, the maximum hourly cost is the sum 
 | AWS      | $0.2792             | $198.91              |
 | OVHcloud | €0.2310             | €180.72              |
 | OCI      | $0.0684             | $48.51               |
+| GCP      | $0.5420             | $395.67              |
+| Azure    | $0.3136             | $228.93              |
 
 ## Safety Nets
 
@@ -34,13 +38,15 @@ If cleanup fails and instances keep running, the maximum hourly cost is the sum 
    - AWS: manual trigger
    - OVHcloud: manual trigger
    - OCI: manual trigger
+   - GCP: manual trigger
+   - Azure: manual trigger
 
 ## Provider Comparison
 
-| | Hetzner | AWS | OVHcloud | OCI |
-|---|---------|-----|----------|-----|
-| Pricing | Simple, flat hourly/monthly | On-demand, region-dependent | Hourly consumption billing | Pay-as-you-go |
-| Hidden fees | None | Egress, EBS IOPS (minimal for benchmarks) | None | Egress |
-| Cheapest instance | €2.99/mo (CX23) | $6.91/mo (t4g.micro) | €14.26/mo (D2-4) | Free tier eligible |
-| Cleanup | hcloud CLI / scheduled workflow | AWS CLI / scheduled workflow | OpenStack CLI / manual workflow | OCI CLI / manual workflow |
-| Billing granularity | Hourly | Per-second | Hourly | Per-second |
+| | Hetzner | AWS | OVHcloud | OCI | GCP | Azure |
+|---|---------|-----|----------|-----|-----|-------|
+| Pricing | Simple, flat hourly/monthly | On-demand, region-dependent | Hourly consumption billing | Pay-as-you-go | Per-second billing | Per-minute billing |
+| Hidden fees | None | Egress, EBS IOPS (minimal for benchmarks) | None | Egress | Egress | Egress |
+| Cheapest instance | €2.99/mo (CX23) | $6.91/mo (t4g.micro) | €14.26/mo (D2-4) | Free tier eligible | $64.19/mo (e2-standard-2) | $29.95/mo (Standard_B2s) |
+| Cleanup | hcloud CLI / scheduled workflow | AWS CLI / scheduled workflow | OpenStack CLI / manual workflow | OCI CLI / manual workflow | gcloud CLI / scheduled workflow | az CLI / scheduled workflow |
+| Billing granularity | Hourly | Per-second | Hourly | Per-second | Per-second | Per-minute |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -67,6 +67,32 @@ oci compute instance list --compartment-id $OCI_COMPARTMENT_ID \
 oci compute instance terminate --instance-id <INSTANCE_OCID> --force
 ```
 
+**Manual fix (GCP)**:
+```bash
+export GCP_PROJECT_ID="your-project-id"
+
+# List cloud-bench instances
+gcloud compute instances list --filter="labels.project=cloud-bench" \
+  --format="table(name,zone,status)" --project="$GCP_PROJECT_ID"
+
+# Delete all cloud-bench instances (per zone)
+gcloud compute instances delete <INSTANCE_NAME> --zone=<ZONE> \
+  --project="$GCP_PROJECT_ID" --quiet
+```
+
+**Manual fix (Azure)**:
+```bash
+az login --service-principal \
+  -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" \
+  --tenant "$AZURE_TENANT_ID"
+
+# List cloud-bench resource groups
+az group list --tag project=cloud-bench --query "[].name" --output tsv
+
+# Delete a specific resource group (contains all run resources)
+az group delete --name <RESOURCE_GROUP_NAME> --yes --no-wait
+```
+
 ## SSH Connection Failures
 
 **Symptom**: "Failed to connect to the host via ssh"
@@ -132,10 +158,12 @@ If you need to stop everything immediately:
 3. **AWS**: EC2 Console (eu-central-1) → terminate all `cloud-bench` tagged instances, delete security groups and key pairs
 4. **OVHcloud**: Horizon Dashboard (DE1) → delete all `cloud-bench-*` instances and key pairs
 5. **OCI**: OCI Console → Compute → Instances → terminate all `cloud-bench-*` instances in your compartment, delete VCNs and security lists
+6. **GCP**: GCP Console → Compute Engine → VM instances → delete all `cloud-bench-*` instances, delete firewall rules tagged `cloud-bench`
+7. **Azure**: Azure Portal → Resource groups → delete all resource groups named `cloud-bench-azure-*`
 
 ## Preventing Issues
 
 - Always wait for the cleanup job to finish (green checkmark)
 - Don't run multiple benchmarks simultaneously (concurrency group prevents this in CI)
-- Set billing alerts: €10 in Hetzner, $10 in AWS, €10 in OVHcloud, $10 in OCI
+- Set billing alerts: €10 in Hetzner, $10 in AWS, €10 in OVHcloud, $10 in OCI, $10 in GCP, $10 in Azure
 - Keep pricing updated — stale prices affect value calculations

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -240,7 +240,7 @@ In Azure Portal, go to **Cost Management + Billing > Budgets** and create a budg
 
 ### 6. Run
 
-Go to **Actions > Run Benchmarks > Run workflow**. Select provider `azure` and region `westeurope`.
+Go to **Actions > Run Benchmarks > Run workflow**. Select provider `azure` and region `germanywestcentral`.
 
 ## Local Run (Cloud Provisioning)
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - GitHub account (for Actions-based benchmarking)
-- Account with one or more providers: Hetzner Cloud, AWS, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP)
+- Account with one or more providers: Hetzner Cloud, AWS, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP), Microsoft Azure
 
 ## Hetzner Setup
 
@@ -205,6 +205,43 @@ In GCP Console, go to **Billing > Budgets & alerts** and create a budget at e.g.
 
 Go to **Actions > Run Benchmarks > Run workflow**. Select provider `gcp` and region `europe-west3`.
 
+## Azure Setup
+
+### 1. Create a dedicated resource group (optional but recommended)
+
+In [Azure Portal](https://portal.azure.com/), a dedicated subscription or resource group makes cost tracking and cleanup straightforward. The Terraform module creates its own resource group per run, so no manual group creation is required.
+
+### 2. Create a service principal
+
+```bash
+az ad sp create-for-rbac --name cloud-bench \
+  --role Contributor \
+  --scopes /subscriptions/<YOUR_SUBSCRIPTION_ID>
+```
+
+This outputs `appId` (client ID), `password` (client secret), `tenant` (tenant ID). Note them — the password is shown only once.
+
+### 3. Collect required identifiers
+
+| Secret | Where to find it |
+|---|---|
+| `AZURE_SUBSCRIPTION_ID` | Azure Portal → Subscriptions — copy the Subscription ID |
+| `AZURE_CLIENT_ID` | Output `appId` from the `az ad sp create-for-rbac` command |
+| `AZURE_CLIENT_SECRET` | Output `password` from the `az ad sp create-for-rbac` command |
+| `AZURE_TENANT_ID` | Output `tenant` from the `az ad sp create-for-rbac` command |
+
+### 4. Add secrets to GitHub
+
+**Repository Settings > Secrets and variables > Actions** — add all four secrets above.
+
+### 5. Set a budget alert
+
+In Azure Portal, go to **Cost Management + Billing > Budgets** and create a budget at e.g. $10.
+
+### 6. Run
+
+Go to **Actions > Run Benchmarks > Run workflow**. Select provider `azure` and region `westeurope`.
+
 ## Local Run (Cloud Provisioning)
 
 Run the full benchmark pipeline locally (provisions cloud instances, runs benchmarks, processes results):
@@ -237,6 +274,13 @@ PROVIDER=oci ./scripts/run-local.sh
 export GCP_PROJECT_ID="your-project-id"
 export GCP_CREDENTIALS="$(cat /path/to/service-account-key.json)"
 PROVIDER=gcp ./scripts/run-local.sh
+
+# Azure
+export AZURE_SUBSCRIPTION_ID="your-subscription-id"
+export AZURE_CLIENT_ID="your-client-id"
+export AZURE_CLIENT_SECRET="your-client-secret"
+export AZURE_TENANT_ID="your-tenant-id"
+PROVIDER=azure ./scripts/run-local.sh
 ```
 
 The script auto-detects your IP for the firewall/security group. It provisions, benchmarks, processes results, and prompts to destroy.
@@ -271,6 +315,9 @@ terraform plan -var="run_id=test" -var="cloud_provider=oci" -var='allowed_ssh_ip
 
 # GCP
 terraform plan -var="run_id=test" -var="cloud_provider=gcp" -var='allowed_ssh_ips=["YOUR_IP/32"]'
+
+# Azure
+terraform plan -var="run_id=test" -var="cloud_provider=azure" -var='allowed_ssh_ips=["YOUR_IP/32"]'
 ```
 
 ## Troubleshooting

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -240,7 +240,7 @@ In Azure Portal, go to **Cost Management + Billing > Budgets** and create a budg
 
 ### 6. Run
 
-Go to **Actions > Run Benchmarks > Run workflow**. Select provider `azure` and region `germanywestcentral`.
+Go to **Actions > Run Benchmarks > Run workflow**. Select provider `azure` and region `northeurope`.
 
 ## Local Run (Cloud Provisioning)
 

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -169,90 +169,35 @@ validate_credentials() {
     fi
 }
 
-# Build terraform var args based on provider
+# Pass every credential var on every run — the OCI and Google provider blocks
+# validate their config at plan time even when no resources of that kind exist.
 build_tf_vars() {
     local action="$1"
+    shift
     local common_vars=(
         -var="run_id=$RUN_ID"
         -var="cloud_provider=$PROVIDER"
         -var="default_region=$REGION"
         -var="ssh_public_key_path=$SSH_PUB_KEY_PATH"
         -var="allowed_ssh_ips=[\"$ALLOWED_SSH_IPS\"]"
+        -var="hcloud_token=${HCLOUD_TOKEN:-0000000000000000000000000000000000000000000000000000000000000000}"
+        -var="aws_access_key_id=${AWS_ACCESS_KEY_ID:-unused}"
+        -var="aws_secret_access_key=${AWS_SECRET_ACCESS_KEY:-unused}"
+        -var="ovh_openstack_username=${OVH_OPENSTACK_USERNAME:-unused}"
+        -var="ovh_openstack_password=${OVH_OPENSTACK_PASSWORD:-unused}"
+        -var="ovh_cloud_project_id=${OVH_CLOUD_PROJECT_ID:-unused}"
+        -var="oci_tenancy_ocid=${OCI_TENANCY_OCID:-unused}"
+        -var="oci_user_ocid=${OCI_USER_OCID:-unused}"
+        -var="oci_fingerprint=${OCI_FINGERPRINT:-unused}"
+        -var="oci_private_key=${OCI_PRIVATE_KEY:-unused}"
+        -var="oci_compartment_id=${OCI_COMPARTMENT_ID:-unused}"
+        -var="gcp_project_id=${GCP_PROJECT_ID:-unused}"
+        -var="gcp_credentials=${GCP_CREDENTIALS:-}"
+        -var="azure_subscription_id=${AZURE_SUBSCRIPTION_ID:-}"
+        -var="azure_client_id=${AZURE_CLIENT_ID:-}"
+        -var="azure_client_secret=${AZURE_CLIENT_SECRET:-}"
+        -var="azure_tenant_id=${AZURE_TENANT_ID:-}"
     )
-
-    case "$PROVIDER" in
-        hetzner)
-            common_vars+=(
-                -var="hcloud_token=$HCLOUD_TOKEN"
-                -var="aws_access_key_id=unused"
-                -var="aws_secret_access_key=unused"
-                -var="ovh_openstack_username=unused"
-                -var="ovh_openstack_password=unused"
-                -var="ovh_cloud_project_id=unused"
-            )
-            ;;
-        aws)
-            common_vars+=(
-                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
-                -var="aws_access_key_id=$AWS_ACCESS_KEY_ID"
-                -var="aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"
-                -var="ovh_openstack_username=unused"
-                -var="ovh_openstack_password=unused"
-                -var="ovh_cloud_project_id=unused"
-            )
-            ;;
-        ovhcloud)
-            common_vars+=(
-                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
-                -var="aws_access_key_id=unused"
-                -var="aws_secret_access_key=unused"
-                -var="ovh_openstack_username=$OVH_OPENSTACK_USERNAME"
-                -var="ovh_openstack_password=$OVH_OPENSTACK_PASSWORD"
-                -var="ovh_cloud_project_id=$OVH_CLOUD_PROJECT_ID"
-            )
-            ;;
-        oci)
-            common_vars+=(
-                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
-                -var="aws_access_key_id=unused"
-                -var="aws_secret_access_key=unused"
-                -var="ovh_openstack_username=unused"
-                -var="ovh_openstack_password=unused"
-                -var="ovh_cloud_project_id=unused"
-                -var="oci_tenancy_ocid=$OCI_TENANCY_OCID"
-                -var="oci_user_ocid=$OCI_USER_OCID"
-                -var="oci_fingerprint=$OCI_FINGERPRINT"
-                -var="oci_private_key=$OCI_PRIVATE_KEY"
-                -var="oci_compartment_id=$OCI_COMPARTMENT_ID"
-            )
-            ;;
-        gcp)
-            common_vars+=(
-                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
-                -var="aws_access_key_id=unused"
-                -var="aws_secret_access_key=unused"
-                -var="ovh_openstack_username=unused"
-                -var="ovh_openstack_password=unused"
-                -var="ovh_cloud_project_id=unused"
-                -var="gcp_project_id=$GCP_PROJECT_ID"
-                -var="gcp_credentials=$GCP_CREDENTIALS"
-            )
-            ;;
-        azure)
-            common_vars+=(
-                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
-                -var="aws_access_key_id=unused"
-                -var="aws_secret_access_key=unused"
-                -var="ovh_openstack_username=unused"
-                -var="ovh_openstack_password=unused"
-                -var="ovh_cloud_project_id=unused"
-                -var="azure_subscription_id=$AZURE_SUBSCRIPTION_ID"
-                -var="azure_client_id=$AZURE_CLIENT_ID"
-                -var="azure_client_secret=$AZURE_CLIENT_SECRET"
-                -var="azure_tenant_id=$AZURE_TENANT_ID"
-            )
-            ;;
-    esac
 
     common_vars+=("$@")
     printf '%s\n' "${common_vars[@]}"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -16,7 +16,7 @@ if [ -z "$REGION" ]; then
         ovhcloud) REGION="DE1" ;;
         oci)      REGION="eu-frankfurt-1" ;;
         gcp)      REGION="europe-west3" ;;
-        azure)    REGION="germanywestcentral" ;;
+        azure)    REGION="northeurope" ;;
         *)        REGION="fsn1" ;;
     esac
 fi
@@ -274,7 +274,7 @@ main() {
     pip install -q -r scripts/requirements.txt 2>/dev/null || true
 
     python3 scripts/process_results.py \
-        --input results/ \
+        --input ansible/results/ \
         --output frontend/public/data/ \
         --config config/instances.yaml \
         --region "$REGION" \

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -16,6 +16,7 @@ if [ -z "$REGION" ]; then
         ovhcloud) REGION="DE1" ;;
         oci)      REGION="eu-frankfurt-1" ;;
         gcp)      REGION="europe-west3" ;;
+        azure)    REGION="westeurope" ;;
         *)        REGION="fsn1" ;;
     esac
 fi
@@ -121,6 +122,22 @@ validate_credentials() {
                 exit 1
             fi
             ;;
+        azure)
+            local azure_missing=()
+            [ -z "$AZURE_SUBSCRIPTION_ID" ] && azure_missing+=("AZURE_SUBSCRIPTION_ID")
+            [ -z "$AZURE_CLIENT_ID" ] && azure_missing+=("AZURE_CLIENT_ID")
+            [ -z "$AZURE_CLIENT_SECRET" ] && azure_missing+=("AZURE_CLIENT_SECRET")
+            [ -z "$AZURE_TENANT_ID" ] && azure_missing+=("AZURE_TENANT_ID")
+            if [ ${#azure_missing[@]} -ne 0 ]; then
+                echo "[ERROR] Azure credentials not set: ${azure_missing[*]}"
+                echo "Set them with:"
+                echo "  export AZURE_SUBSCRIPTION_ID=your-subscription-id"
+                echo "  export AZURE_CLIENT_ID=your-client-id"
+                echo "  export AZURE_CLIENT_SECRET=your-client-secret"
+                echo "  export AZURE_TENANT_ID=your-tenant-id"
+                exit 1
+            fi
+            ;;
         *)
             echo "[ERROR] Unsupported provider: $PROVIDER"
             exit 1
@@ -219,6 +236,20 @@ build_tf_vars() {
                 -var="ovh_cloud_project_id=unused"
                 -var="gcp_project_id=$GCP_PROJECT_ID"
                 -var="gcp_credentials=$GCP_CREDENTIALS"
+            )
+            ;;
+        azure)
+            common_vars+=(
+                -var="hcloud_token=0000000000000000000000000000000000000000000000000000000000000000"
+                -var="aws_access_key_id=unused"
+                -var="aws_secret_access_key=unused"
+                -var="ovh_openstack_username=unused"
+                -var="ovh_openstack_password=unused"
+                -var="ovh_cloud_project_id=unused"
+                -var="azure_subscription_id=$AZURE_SUBSCRIPTION_ID"
+                -var="azure_client_id=$AZURE_CLIENT_ID"
+                -var="azure_client_secret=$AZURE_CLIENT_SECRET"
+                -var="azure_tenant_id=$AZURE_TENANT_ID"
             )
             ;;
     esac

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -16,7 +16,7 @@ if [ -z "$REGION" ]; then
         ovhcloud) REGION="DE1" ;;
         oci)      REGION="eu-frankfurt-1" ;;
         gcp)      REGION="europe-west3" ;;
-        azure)    REGION="westeurope" ;;
+        azure)    REGION="germanywestcentral" ;;
         *)        REGION="fsn1" ;;
     esac
 fi

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -582,12 +582,13 @@ def fetch_azure_pricing(config: dict, azure_region: str = "westeurope") -> int:
             print(f"  [WARN] Failed to fetch pricing for {inst_id}: {e}")
             continue
 
-        # Keep only Linux on-demand (exclude Windows premium and Spot)
         linux_items = [
             item
             for item in items
             if "Windows" not in item.get("productName", "")
+            and "Cloud Services" not in item.get("productName", "")
             and "Spot" not in item.get("skuName", "")
+            and "Low Priority" not in item.get("skuName", "")
             and item.get("type") == "Consumption"
         ]
 

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -548,6 +548,72 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
     return updated
 
 
+def fetch_azure_pricing(config: dict, azure_region: str = "westeurope") -> int:
+    """Fetch Azure VM pricing using the Retail Prices API (public, no auth).
+    Returns count of updated instances."""
+    azure_config = config.get("providers", {}).get("azure", {})
+    instances = azure_config.get("instances", [])
+    if not instances:
+        print("  [WARN] No Azure instances in config")
+        return 0
+
+    # Azure Retail Prices API — no authentication required
+    api_url = "https://prices.azure.com/api/retail/prices"
+    updated = 0
+
+    for inst in instances:
+        inst_id = inst.get("id", "")
+        try:
+            response = requests.get(
+                api_url,
+                params={
+                    "$filter": (
+                        f"armSkuName eq '{inst_id}' "
+                        f"and armRegionName eq '{azure_region}' "
+                        f"and serviceName eq 'Virtual Machines' "
+                        f"and priceType eq 'Consumption'"
+                    )
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            items = response.json().get("Items", [])
+        except requests.RequestException as e:
+            print(f"  [WARN] Failed to fetch pricing for {inst_id}: {e}")
+            continue
+
+        # Keep only Linux on-demand (exclude Windows premium and Spot)
+        linux_items = [
+            item
+            for item in items
+            if "Windows" not in item.get("productName", "")
+            and "Spot" not in item.get("skuName", "")
+            and item.get("type") == "Consumption"
+        ]
+
+        if not linux_items:
+            print(f"  [WARN] No Linux pricing found for {inst_id} in {azure_region}")
+            continue
+
+        # Take the lowest on-demand hourly rate
+        hourly = round(min(item.get("retailPrice", 0) for item in linux_items), 5)
+        if hourly <= 0:
+            print(f"  [WARN] Zero pricing returned for {inst_id}")
+            continue
+
+        monthly = round(hourly * 720, 2)
+
+        old_pricing = inst.get("pricing", {})
+        if old_pricing.get("hourly") != hourly or old_pricing.get("monthly") != monthly:
+            inst["pricing"] = {"hourly": hourly, "monthly": monthly}
+            updated += 1
+            print(f"  [UPDATED] {inst_id}: ${monthly}/mo")
+        else:
+            print(f"  [OK] {inst_id}: ${monthly}/mo (unchanged)")
+
+    return updated
+
+
 def fetch_exchange_rates() -> dict:
     """Fetch EUR/USD rate from Frankfurter API (ECB data, free, no key)."""
     try:
@@ -576,6 +642,7 @@ def update_config(
     dry_run: bool = False,
     provider: str = "all",
     aws_region: str = "eu-central-1",
+    azure_region: str = "westeurope",
 ) -> dict:
     """Update instances.yaml with fetched pricing."""
     with open(config_path) as f:
@@ -608,6 +675,11 @@ def update_config(
         print("\nUpdating GCP pricing...")
         total_updated += fetch_gcp_pricing(config)
 
+    # Update Azure pricing
+    if provider in ("all", "azure"):
+        print("\nUpdating Azure pricing...")
+        total_updated += fetch_azure_pricing(config, azure_region)
+
     # Update exchange rates
     print("\nFetching exchange rates...")
     exchange_rates = fetch_exchange_rates()
@@ -625,7 +697,7 @@ def update_config(
     if not dry_run and total_updated > 0:
         config["_metadata"] = {
             "last_pricing_update": datetime.now().isoformat(),
-            "source": "Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing API / GCP Cloud Billing API",
+            "source": "Hetzner Cloud API / AWS Pricing API / OVH Catalog API / OCI APEX Pricing API / GCP Cloud Billing API / Azure Retail Prices API",
         }
         with open(config_path, "w") as f:
             yaml.dump(
@@ -652,13 +724,18 @@ def main():
         "--provider",
         "-p",
         default="all",
-        choices=["hetzner", "aws", "ovhcloud", "oci", "gcp", "all"],
+        choices=["hetzner", "aws", "ovhcloud", "oci", "gcp", "azure", "all"],
         help="Provider to update pricing for",
     )
     parser.add_argument(
         "--aws-region",
         default="eu-central-1",
         help="AWS region for pricing (default: eu-central-1)",
+    )
+    parser.add_argument(
+        "--azure-region",
+        default="westeurope",
+        help="Azure region for pricing (default: westeurope)",
     )
     parser.add_argument(
         "--dry-run", "-n", action="store_true", help="Show changes without saving"
@@ -691,6 +768,7 @@ def main():
             dry_run=args.dry_run,
             provider=args.provider,
             aws_region=args.aws_region,
+            azure_region=args.azure_region,
         )
     except yaml.YAMLError as e:
         print(f"[ERROR] YAML parsing failed: {e}")

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -548,7 +548,7 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
     return updated
 
 
-def fetch_azure_pricing(config: dict, azure_region: str = "westeurope") -> int:
+def fetch_azure_pricing(config: dict, azure_region: str = "germanywestcentral") -> int:
     """Fetch Azure VM pricing using the Retail Prices API (public, no auth).
     Returns count of updated instances."""
     azure_config = config.get("providers", {}).get("azure", {})
@@ -643,7 +643,7 @@ def update_config(
     dry_run: bool = False,
     provider: str = "all",
     aws_region: str = "eu-central-1",
-    azure_region: str = "westeurope",
+    azure_region: str = "germanywestcentral",
 ) -> dict:
     """Update instances.yaml with fetched pricing."""
     with open(config_path) as f:
@@ -735,8 +735,8 @@ def main():
     )
     parser.add_argument(
         "--azure-region",
-        default="westeurope",
-        help="Azure region for pricing (default: westeurope)",
+        default="germanywestcentral",
+        help="Azure region for pricing (default: germanywestcentral)",
     )
     parser.add_argument(
         "--dry-run", "-n", action="store_true", help="Show changes without saving"

--- a/scripts/update_pricing.py
+++ b/scripts/update_pricing.py
@@ -548,7 +548,7 @@ def fetch_gcp_pricing(config: dict, gcp_region: str = "europe-west3") -> int:
     return updated
 
 
-def fetch_azure_pricing(config: dict, azure_region: str = "germanywestcentral") -> int:
+def fetch_azure_pricing(config: dict, azure_region: str = "northeurope") -> int:
     """Fetch Azure VM pricing using the Retail Prices API (public, no auth).
     Returns count of updated instances."""
     azure_config = config.get("providers", {}).get("azure", {})
@@ -643,7 +643,7 @@ def update_config(
     dry_run: bool = False,
     provider: str = "all",
     aws_region: str = "eu-central-1",
-    azure_region: str = "germanywestcentral",
+    azure_region: str = "northeurope",
 ) -> dict:
     """Update instances.yaml with fetched pricing."""
     with open(config_path) as f:
@@ -735,8 +735,8 @@ def main():
     )
     parser.add_argument(
         "--azure-region",
-        default="germanywestcentral",
-        help="Azure region for pricing (default: germanywestcentral)",
+        default="northeurope",
+        help="Azure region for pricing (default: northeurope)",
     )
     parser.add_argument(
         "--dry-run", "-n", action="store_true", help="Show changes without saving"

--- a/terraform/dummy_credentials.tf
+++ b/terraform/dummy_credentials.tf
@@ -1,0 +1,37 @@
+# The OCI and Google providers validate credentials at provider Configure()
+# even when no resources of that kind exist — without these fallbacks, every
+# benchmark run would need OCI and Google secrets set. The PEM below is a
+# throwaway 1024-bit RSA key generated for this purpose only.
+locals {
+  _dummy_pem = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAMZix/vhzC6c5GSK
+iljLDC6Iwk91hRdJ0zCDc2gJxe0NdnCkFIZPBgkkcvAmCI+d9OxEH6emL800iULa
+kwEu7sZQqj8IKnf4IdTFp+s/JpBigFbvOtsnapvbmnn4ogypk51XQHTbzwiSynF6
+MEMJ0tJIe8em40YYef8h9nsnjvh/AgMBAAECgYBvIuN5nfLuogHouRvrxkQaxY5l
+SSa39ymSYfGC9QamWAZj7+d3nkl5Uav6ELR3EDwnJ7q8BoN859OFWkFERnCIN3ph
+lfF/3u9Qlqp5qPDv3FpiFs/CbI+y22UCR8l6eDwYVANx3rWul62RyF9eb7yPMoIr
+YVHp7NH7LG26nDAz8QJBAPJVqyz+SsuljtLoxNKhuX/A2pG92s9dgM998O7e/1jU
+iKIRy/2nH1BkzyUyUrZqegdRuzt7TJheUMfrqi02x8sCQQDRkquIl8hCmE6qFR9m
+PTym59PS6V0/XddKs03HD8dzJXc/MJlRPQecCdVxcmvHX18GUW6H2KH49i5pYEu6
+WzOdAkBHFJfD98bKmwIcnQf2XFeDwHab3xtKTbvVoLRF7ITrclOtbhjuitGljBwy
+ZeNa/DpU4UVQ+iaKXsfFDDv7TSEnAkEAsKRmbqg4hGEqFNPe9mbxI2FNun02On3X
+REBjc0CKhTR0EU/eOootSslDHe8qhw6M4p9qgZgH1fdyYSFoUvgiRQJAedERaXEA
+RlJwtWWs+iVibMHc7kId2iD/HFhn9FHku2nbyZaFTB24jxm1sBNLInRlhtVABlr3
+DqBrMQ5gOYM2fg==
+-----END PRIVATE KEY-----
+EOT
+
+  _dummy_gcp_credentials = jsonencode({
+    type                        = "service_account"
+    project_id                  = "dummy"
+    private_key_id              = "0000000000000000000000000000000000000000"
+    private_key                 = local._dummy_pem
+    client_email                = "dummy@dummy.iam.gserviceaccount.com"
+    client_id                   = "0"
+    auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+    token_uri                   = "https://oauth2.googleapis.com/token"
+    auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+    client_x509_cert_url        = "https://www.googleapis.com/robot/v1/metadata/x509/dummy"
+  })
+}

--- a/terraform/dummy_credentials.tf
+++ b/terraform/dummy_credentials.tf
@@ -1,26 +1,13 @@
 # The OCI and Google providers validate credentials at provider Configure()
 # even when no resources of that kind exist — without these fallbacks, every
-# benchmark run would need OCI and Google secrets set. The PEM below is a
-# throwaway 1024-bit RSA key generated for this purpose only.
+# benchmark run would need OCI and Google secrets set. The PEM is generated
+# fresh per plan via openssl so no static key lives in the repo.
+data "external" "dummy_pem" {
+  program = ["sh", "-c", "openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:1024 2>/dev/null | jq -Rs '{pem: .}'"]
+}
+
 locals {
-  _dummy_pem = <<EOT
------BEGIN PRIVATE KEY-----
-MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAMZix/vhzC6c5GSK
-iljLDC6Iwk91hRdJ0zCDc2gJxe0NdnCkFIZPBgkkcvAmCI+d9OxEH6emL800iULa
-kwEu7sZQqj8IKnf4IdTFp+s/JpBigFbvOtsnapvbmnn4ogypk51XQHTbzwiSynF6
-MEMJ0tJIe8em40YYef8h9nsnjvh/AgMBAAECgYBvIuN5nfLuogHouRvrxkQaxY5l
-SSa39ymSYfGC9QamWAZj7+d3nkl5Uav6ELR3EDwnJ7q8BoN859OFWkFERnCIN3ph
-lfF/3u9Qlqp5qPDv3FpiFs/CbI+y22UCR8l6eDwYVANx3rWul62RyF9eb7yPMoIr
-YVHp7NH7LG26nDAz8QJBAPJVqyz+SsuljtLoxNKhuX/A2pG92s9dgM998O7e/1jU
-iKIRy/2nH1BkzyUyUrZqegdRuzt7TJheUMfrqi02x8sCQQDRkquIl8hCmE6qFR9m
-PTym59PS6V0/XddKs03HD8dzJXc/MJlRPQecCdVxcmvHX18GUW6H2KH49i5pYEu6
-WzOdAkBHFJfD98bKmwIcnQf2XFeDwHab3xtKTbvVoLRF7ITrclOtbhjuitGljBwy
-ZeNa/DpU4UVQ+iaKXsfFDDv7TSEnAkEAsKRmbqg4hGEqFNPe9mbxI2FNun02On3X
-REBjc0CKhTR0EU/eOootSslDHe8qhw6M4p9qgZgH1fdyYSFoUvgiRQJAedERaXEA
-RlJwtWWs+iVibMHc7kId2iD/HFhn9FHku2nbyZaFTB24jxm1sBNLInRlhtVABlr3
-DqBrMQ5gOYM2fg==
------END PRIVATE KEY-----
-EOT
+  _dummy_pem = data.external.dummy_pem.result.pem
 
   _dummy_gcp_credentials = jsonencode({
     type                        = "service_account"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -109,7 +109,7 @@ locals {
       ovhcloud = "DE1"
       oci      = "eu-frankfurt-1"
       gcp      = "europe-west3"
-      azure    = "germanywestcentral"
+      azure    = "northeurope"
     },
     var.cloud_provider,
     "fsn1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -109,7 +109,7 @@ locals {
       ovhcloud = "DE1"
       oci      = "eu-frankfurt-1"
       gcp      = "europe-west3"
-      azure    = "westeurope"
+      azure    = "germanywestcentral"
     },
     var.cloud_provider,
     "fsn1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,17 +58,17 @@ provider "openstack" {
 }
 
 provider "oci" {
-  tenancy_ocid = var.oci_tenancy_ocid
-  user_ocid    = var.oci_user_ocid
-  fingerprint  = var.oci_fingerprint
-  private_key  = var.oci_private_key
+  tenancy_ocid = var.oci_tenancy_ocid != "" && var.oci_tenancy_ocid != "unused" ? var.oci_tenancy_ocid : "ocid1.tenancy.oc1..unused"
+  user_ocid    = var.oci_user_ocid != "" && var.oci_user_ocid != "unused" ? var.oci_user_ocid : "ocid1.user.oc1..unused"
+  fingerprint  = var.oci_fingerprint != "" && var.oci_fingerprint != "unused" ? var.oci_fingerprint : "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+  private_key  = var.oci_private_key != "" && var.oci_private_key != "unused" ? var.oci_private_key : local._dummy_pem
   region       = var.cloud_provider == "oci" ? local.effective_region : "eu-frankfurt-1"
 }
 
 provider "google" {
-  project     = var.gcp_project_id
+  project     = var.gcp_project_id != "" && var.gcp_project_id != "unused" ? var.gcp_project_id : "dummy"
   region      = var.cloud_provider == "gcp" ? local.effective_region : "europe-west3"
-  credentials = var.gcp_credentials != "" ? var.gcp_credentials : null
+  credentials = var.gcp_credentials != "" ? var.gcp_credentials : local._dummy_gcp_credentials
 }
 
 provider "azurerm" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.1"
     }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
   }
 
   backend "local" {
@@ -67,6 +71,19 @@ provider "google" {
   credentials = var.gcp_credentials != "" ? var.gcp_credentials : null
 }
 
+provider "azurerm" {
+  features {}
+  subscription_id = var.azure_subscription_id != "" ? var.azure_subscription_id : "00000000-0000-0000-0000-000000000000"
+  client_id       = var.azure_client_id != "" ? var.azure_client_id : "00000000-0000-0000-0000-000000000000"
+  client_secret   = var.azure_client_secret != "" ? var.azure_client_secret : "unused"
+  tenant_id       = var.azure_tenant_id != "" ? var.azure_tenant_id : "00000000-0000-0000-0000-000000000000"
+  use_cli         = false
+  use_msi         = false
+  use_oidc        = false
+  # skip_provider_registration avoids an extra API call when not using Azure
+  skip_provider_registration = true
+}
+
 locals {
   config = yamldecode(file("${path.module}/../config/instances.yaml"))
 
@@ -92,6 +109,7 @@ locals {
       ovhcloud = "DE1"
       oci      = "eu-frankfurt-1"
       gcp      = "europe-west3"
+      azure    = "westeurope"
     },
     var.cloud_provider,
     "fsn1"
@@ -180,6 +198,20 @@ module "gcp_instances" {
   labels          = merge(local.common_labels, { instance_type = replace(each.value.id, ".", "-") })
 }
 
+module "azure_instances" {
+  source   = "./modules/azure"
+  for_each = var.cloud_provider == "azure" ? { for inst in local.instances : inst.id => inst } : {}
+
+  instance_name   = "cloud-bench-azure-${replace(each.value.id, "_", "-")}-${var.run_id}"
+  instance_type   = each.value.id
+  instance_arch   = lookup(local.arch_map, each.value.arch, "x86_64")
+  region          = lookup(var.instance_regions, each.value.id, local.effective_region)
+  ssh_public_key  = local.ssh_public_key
+  allowed_ssh_ips = var.allowed_ssh_ips
+  disk_size_gb    = var.azure_disk_size
+  tags            = merge(local.common_labels, { instance_type = replace(each.value.id, "_", "-") })
+}
+
 locals {
   all_instances = merge(
     {
@@ -208,6 +240,12 @@ locals {
     },
     {
       for inst_id, mod in module.gcp_instances : inst_id => {
+        host = mod.server_ip
+        name = mod.server_name
+      }
+    },
+    {
+      for inst_id, mod in module.azure_instances : inst_id => {
         host = mod.server_ip
         name = mod.server_name
       }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
   }
 
   backend "local" {

--- a/terraform/modules/azure/cloud-init.yml.tmpl
+++ b/terraform/modules/azure/cloud-init.yml.tmpl
@@ -1,0 +1,10 @@
+#cloud-config
+
+runcmd:
+  - mkdir -p /opt/cloud-bench
+  - chmod 755 /opt/cloud-bench
+  - sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+  - sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+final_message: "Cloud-bench instance setup complete!"

--- a/terraform/modules/azure/main.tf
+++ b/terraform/modules/azure/main.tf
@@ -1,0 +1,131 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+locals {
+  # Azure VM names: alphanumeric and hyphens only
+  safe_name = replace(var.instance_name, "_", "-")
+
+  cloud_init = templatefile("${path.module}/cloud-init.yml.tmpl", {})
+
+  image_reference = var.instance_arch == "arm64" ? {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-arm64"
+    version   = "latest"
+    } : {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_resource_group" "benchmark" {
+  name     = local.safe_name
+  location = var.region
+  tags     = var.tags
+}
+
+resource "azurerm_virtual_network" "benchmark" {
+  name                = "${local.safe_name}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.benchmark.location
+  resource_group_name = azurerm_resource_group.benchmark.name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "benchmark" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.benchmark.name
+  virtual_network_name = azurerm_virtual_network.benchmark.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_security_group" "benchmark" {
+  name                = "${local.safe_name}-nsg"
+  location            = azurerm_resource_group.benchmark.location
+  resource_group_name = azurerm_resource_group.benchmark.name
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                        = "allow-ssh"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefixes     = var.allowed_ssh_ips
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.benchmark.name
+  network_security_group_name = azurerm_network_security_group.benchmark.name
+}
+
+resource "azurerm_public_ip" "benchmark" {
+  name                = "${local.safe_name}-pip"
+  location            = azurerm_resource_group.benchmark.location
+  resource_group_name = azurerm_resource_group.benchmark.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_network_interface" "benchmark" {
+  name                = "${local.safe_name}-nic"
+  location            = azurerm_resource_group.benchmark.location
+  resource_group_name = azurerm_resource_group.benchmark.name
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.benchmark.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.benchmark.id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "benchmark" {
+  network_interface_id      = azurerm_network_interface.benchmark.id
+  network_security_group_id = azurerm_network_security_group.benchmark.id
+}
+
+resource "azurerm_linux_virtual_machine" "benchmark" {
+  name                = local.safe_name
+  resource_group_name = azurerm_resource_group.benchmark.name
+  location            = azurerm_resource_group.benchmark.location
+  size                = var.instance_type
+  admin_username      = "ubuntu"
+
+  network_interface_ids = [
+    azurerm_network_interface.benchmark.id,
+  ]
+
+  admin_ssh_key {
+    username   = "ubuntu"
+    public_key = var.ssh_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = var.disk_type
+    disk_size_gb         = var.disk_size_gb
+  }
+
+  source_image_reference {
+    publisher = local.image_reference.publisher
+    offer     = local.image_reference.offer
+    sku       = local.image_reference.sku
+    version   = local.image_reference.version
+  }
+
+  custom_data = base64encode(local.cloud_init)
+
+  tags = var.tags
+}

--- a/terraform/modules/azure/outputs.tf
+++ b/terraform/modules/azure/outputs.tf
@@ -1,0 +1,19 @@
+output "server_ip" {
+  description = "Public IP address of the instance"
+  value       = azurerm_public_ip.benchmark.ip_address
+}
+
+output "server_name" {
+  description = "Name of the instance"
+  value       = var.instance_name
+}
+
+output "instance_id" {
+  description = "Azure VM resource ID"
+  value       = azurerm_linux_virtual_machine.benchmark.id
+}
+
+output "resource_group" {
+  description = "Resource group containing this instance"
+  value       = azurerm_resource_group.benchmark.name
+}

--- a/terraform/modules/azure/variables.tf
+++ b/terraform/modules/azure/variables.tf
@@ -4,7 +4,7 @@ variable "instance_name" {
 }
 
 variable "instance_type" {
-  description = "Azure VM size (e.g. Standard_D2s_v5)"
+  description = "Azure VM size (e.g. Standard_D2ps_v6)"
   type        = string
 }
 

--- a/terraform/modules/azure/variables.tf
+++ b/terraform/modules/azure/variables.tf
@@ -1,0 +1,63 @@
+variable "instance_name" {
+  description = "Name for the Azure VM and associated resources"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Azure VM size (e.g. Standard_D2s_v5)"
+  type        = string
+}
+
+variable "instance_arch" {
+  description = "Instance architecture: x86_64 or arm64"
+  type        = string
+  default     = "x86_64"
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.instance_arch)
+    error_message = "instance_arch must be x86_64 or arm64"
+  }
+}
+
+variable "region" {
+  description = "Azure region (e.g. westeurope)"
+  type        = string
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content"
+  type        = string
+}
+
+variable "allowed_ssh_ips" {
+  description = "CIDR blocks allowed SSH access"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.allowed_ssh_ips) > 0
+    error_message = "At least one allowed SSH IP must be specified"
+  }
+}
+
+variable "disk_size_gb" {
+  description = "OS disk size in GB"
+  type        = number
+  default     = 30
+}
+
+variable "disk_type" {
+  description = "OS disk storage account type (Premium_LRS, Standard_LRS, StandardSSD_LRS)"
+  type        = string
+  default     = "Premium_LRS"
+
+  validation {
+    condition     = contains(["Premium_LRS", "Standard_LRS", "StandardSSD_LRS", "UltraSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.disk_type)
+    error_message = "disk_type must be a valid Azure managed disk storage type"
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,8 +20,8 @@ variable "cloud_provider" {
   default     = "hetzner"
 
   validation {
-    condition     = can(regex("^(hetzner|aws|ovhcloud|oci|gcp)$", var.cloud_provider))
-    error_message = "Provider must be 'hetzner', 'aws', 'ovhcloud', 'oci', or 'gcp'."
+    condition     = can(regex("^(hetzner|aws|ovhcloud|oci|gcp|azure)$", var.cloud_provider))
+    error_message = "Provider must be 'hetzner', 'aws', 'ovhcloud', 'oci', 'gcp', or 'azure'."
   }
 }
 
@@ -175,4 +175,38 @@ variable "gcp_disk_size" {
   description = "Boot disk size in GB for GCP instances"
   type        = number
   default     = 20
+}
+
+variable "azure_subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "azure_client_id" {
+  description = "Azure service principal client ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "azure_client_secret" {
+  description = "Azure service principal client secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "azure_tenant_id" {
+  description = "Azure tenant ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "azure_disk_size" {
+  description = "OS disk size in GB for Azure instances"
+  type        = number
+  default     = 30
 }

--- a/tests/test_update_pricing.py
+++ b/tests/test_update_pricing.py
@@ -702,5 +702,278 @@ class TestMainGCP(unittest.TestCase):
             os.unlink(temp_path)
 
 
+class TestFetchAzurePricing(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "providers": {
+                "azure": {
+                    "instances": [
+                        {
+                            "id": "Standard_D2as_v7",
+                            "name": "D2as v7",
+                            "vcpu": 2,
+                            "ram_gb": 8,
+                            "pricing": {"hourly": 0.05, "monthly": 36.0},
+                        },
+                        {
+                            "id": "Standard_D2ps_v6",
+                            "name": "D2ps v6",
+                            "vcpu": 2,
+                            "ram_gb": 8,
+                            "pricing": {"hourly": 0.04, "monthly": 28.8},
+                        },
+                    ]
+                }
+            }
+        }
+
+    @staticmethod
+    def _mock_response(items):
+        resp = MagicMock()
+        resp.json.return_value = {"Items": items}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_fetch_azure_pricing_no_instances(self):
+        config = {"providers": {"azure": {"instances": []}}}
+        self.assertEqual(up.fetch_azure_pricing(config), 0)
+
+    def test_fetch_azure_pricing_no_azure_config(self):
+        self.assertEqual(up.fetch_azure_pricing({"providers": {}}), 0)
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_success(self, mock_get):
+        mock_get.side_effect = [
+            self._mock_response(
+                [
+                    {
+                        "armSkuName": "Standard_D2as_v7",
+                        "productName": "Virtual Machines DASv7 Series",
+                        "skuName": "D2as v7",
+                        "type": "Consumption",
+                        "retailPrice": 0.096,
+                    }
+                ]
+            ),
+            self._mock_response(
+                [
+                    {
+                        "armSkuName": "Standard_D2ps_v6",
+                        "productName": "Virtual Machines DPSv6 Series",
+                        "skuName": "D2ps v6",
+                        "type": "Consumption",
+                        "retailPrice": 0.0688,
+                    }
+                ]
+            ),
+        ]
+
+        result = up.fetch_azure_pricing(self.config, azure_region="northeurope")
+
+        self.assertEqual(result, 2)
+        self.assertEqual(
+            self.config["providers"]["azure"]["instances"][0]["pricing"]["hourly"],
+            0.096,
+        )
+        self.assertEqual(
+            self.config["providers"]["azure"]["instances"][0]["pricing"]["monthly"],
+            69.12,
+        )
+        self.assertEqual(
+            self.config["providers"]["azure"]["instances"][1]["pricing"]["hourly"],
+            0.0688,
+        )
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_unchanged(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            [
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0.05,
+                }
+            ]
+        )
+
+        config = {
+            "providers": {
+                "azure": {
+                    "instances": [
+                        {
+                            "id": "Standard_D2as_v7",
+                            "vcpu": 2,
+                            "ram_gb": 8,
+                            "pricing": {"hourly": 0.05, "monthly": 36.0},
+                        }
+                    ]
+                }
+            }
+        }
+        self.assertEqual(up.fetch_azure_pricing(config), 0)
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_excluded_terms(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            [
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series Windows",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0.20,
+                },
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series",
+                    "skuName": "D2as v7 Spot",
+                    "type": "Consumption",
+                    "retailPrice": 0.01,
+                },
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series",
+                    "skuName": "D2as v7 Low Priority",
+                    "type": "Consumption",
+                    "retailPrice": 0.02,
+                },
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Cloud Services DASv7",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0.03,
+                },
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0.10,
+                },
+            ]
+        )
+
+        config = {
+            "providers": {
+                "azure": {
+                    "instances": [
+                        {
+                            "id": "Standard_D2as_v7",
+                            "vcpu": 2,
+                            "ram_gb": 8,
+                            "pricing": {"hourly": 0.0, "monthly": 0.0},
+                        }
+                    ]
+                }
+            }
+        }
+        result = up.fetch_azure_pricing(config)
+        self.assertEqual(result, 1)
+        self.assertEqual(
+            config["providers"]["azure"]["instances"][0]["pricing"]["hourly"], 0.10
+        )
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_api_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.RequestException("API down")
+        self.assertEqual(up.fetch_azure_pricing(self.config), 0)
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_no_linux_items(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            [
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series Windows",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0.20,
+                }
+            ]
+        )
+        self.assertEqual(up.fetch_azure_pricing(self.config), 0)
+
+    @patch("update_pricing.requests.get")
+    def test_fetch_azure_pricing_zero_price(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            [
+                {
+                    "armSkuName": "Standard_D2as_v7",
+                    "productName": "Virtual Machines DASv7 Series",
+                    "skuName": "D2as v7",
+                    "type": "Consumption",
+                    "retailPrice": 0,
+                }
+            ]
+        )
+        self.assertEqual(up.fetch_azure_pricing(self.config), 0)
+
+
+class TestUpdateConfigAzure(unittest.TestCase):
+    @patch("update_pricing.fetch_azure_pricing", return_value=1)
+    @patch("update_pricing.fetch_exchange_rates", return_value={})
+    def test_update_config_azure_provider(self, mock_rates, mock_fetch_azure):
+        config = {
+            "providers": {
+                "azure": {
+                    "instances": [
+                        {
+                            "id": "Standard_D2as_v7",
+                            "vcpu": 2,
+                            "ram_gb": 8,
+                            "pricing": {"hourly": 0.05, "monthly": 36.0},
+                        }
+                    ]
+                }
+            }
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_path = f.name
+
+        try:
+            result = up.update_config(temp_path, [], dry_run=False, provider="azure")
+            mock_fetch_azure.assert_called_once()
+            self.assertIn("_metadata", result)
+            self.assertIn("Azure Retail Prices API", result["_metadata"]["source"])
+        finally:
+            os.unlink(temp_path)
+
+
+class TestMainAzure(unittest.TestCase):
+    @patch("update_pricing.fetch_azure_pricing", return_value=0)
+    @patch("update_pricing.fetch_server_types", return_value=[])
+    @patch("update_pricing.fetch_exchange_rates", return_value={})
+    def test_main_azure_provider(self, mock_rates, mock_server, mock_azure):
+        config = {"providers": {"azure": {"instances": []}}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "update_pricing",
+                    "--provider",
+                    "azure",
+                    "--azure-region",
+                    "westeurope",
+                    "--config",
+                    temp_path,
+                ],
+            ):
+                up.main()
+            mock_azure.assert_called_once()
+            self.assertEqual(mock_azure.call_args.args[1], "westeurope")
+        finally:
+            os.unlink(temp_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Promotes the GCP and Azure provider work (plus follow-up fixes) from develop to main.

- New providers: GCP (Cloud Billing API pricing, compute module, hyperdisk auto-select) and Azure (Retail Prices API, NSG, D2as_v7 + D2ps_v6 in northeurope)
- Terraform: dummy PEM generated at plan time via openssl/data.external so trivy stops flagging it; oci/google providers no longer require real creds for unrelated runs
- Scripts: \`run-local.sh\` adds gcp/azure paths; \`update_pricing.py\` gains Azure + GCP fetchers with exclusion filters (Windows, Spot, Low Priority, Cloud Services)
- CI: GCP/Azure cleanup workflows, \`auth@v2\` + \`setup-gcloud@v3\`, dynamic cost calculation from instances.yaml
- Frontend: per-provider storage-included indicator
- Tests: full coverage for fetch_gcp_pricing and fetch_azure_pricing

## Related issue

Fixes #

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes