### PR TITLE
fix: remove unused displayProviderNames causing TDZ error

### DIFF
--- a/frontend/src/components/InstanceFilter.jsx
+++ b/frontend/src/components/InstanceFilter.jsx
@@ -5,7 +5,6 @@ function InstanceFilter({ ranking, filters, onFilterChange, currency, currencyTo
 
   const arches = [...new Set(ranking.map(r => r.arch))].filter(Boolean).sort()
   const providers = [...new Set(ranking.map(r => r.provider))].filter(Boolean).sort()
-  const displayProviderNames = { aws: 'AWS', hetzner: 'Hetzner', ovhcloud: 'OVH', oci: 'OCI', gcp: 'GCP', azure: 'Azure' }
 
   const maxPrice = Math.ceil(Math.max(...ranking.map(r => r.price_monthly)) * 1.2)
 


### PR DESCRIPTION
## What changed

Remove unused  variable from InstanceFilter causing a Temporal Dead Zone (TDZ) error in the production Vite build.

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes