### PR TITLE
fix: restore benchmark and dashboard runtime

### DIFF
--- a/.github/workflows/benchmark-all.yml
+++ b/.github/workflows/benchmark-all.yml
@@ -296,7 +296,7 @@ jobs:
             -var="enabled_instances=${{ steps.instances.outputs.arg }}" \
             -var="default_region=${{ matrix.region }}" \
             -var="ssh_public_key_path=/dev/null" \
-            -var="allowed_ssh_ips=[\"${{ steps.get_ip.outputs.ip }}/32\"]" || true
+            -var="allowed_ssh_ips=[\"${{ steps.get_ip.outputs.ip }}/32\"]"
 
       - name: Verify Cleanup (${{ matrix.provider }})
         if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -280,6 +280,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ needs.provision.outputs.region }}
         run: |
           RUNNER_IP=$(curl -s --retry 3 https://ifconfig.me || curl -s --retry 3 https://api.ipify.org)
+          export RUNNER_IP
           echo "Benchmark runner IP: $RUNNER_IP"
           PREV_IP="${{ needs.provision.outputs.runner_ip }}"
           echo "Provision runner IP: $PREV_IP"
@@ -431,7 +432,7 @@ jobs:
           }
           compartment_id = os.environ["OCI_COMPARTMENT_ID"]
           run_id = "${{ env.RUN_ID }}"
-          new_ip = os.popen("curl -s --retry 3 https://ifconfig.me || curl -s --retry 3 https://api.ipify.org").read().strip()
+          new_ip = os.environ["RUNNER_IP"]
 
           network = oci.core.VirtualNetworkClient(config)
 
@@ -889,9 +890,11 @@ jobs:
       - name: Post Results Summary
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
+        env:
+          BENCHMARK_SUMMARY: ${{ needs.process.outputs.summary }}
         with:
           script: |
-            const summary = `${{ needs.process.outputs.summary }}`;
+            const summary = process.env.BENCHMARK_SUMMARY || "";
 
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/ansible/playbooks/benchmark.yml
+++ b/ansible/playbooks/benchmark.yml
@@ -96,6 +96,8 @@
               timeout 300 sysbench cpu --cpu-max-prime={{ sysbench_cpu_prime }} --threads=1 run \
                 | grep "events per second" | awk '{print $4}'
             done > "{{ results_dir }}/cpu-single-raw.txt"
+          args:
+            executable: /bin/bash
           changed_when: true
           register: cpu_single_run
           retries: 2
@@ -128,6 +130,8 @@
               sysbench cpu --cpu-max-prime={{ sysbench_cpu_prime }} --threads={{ ansible_processor_vcpus }} run \
                 | grep "events per second" | awk '{print $4}'
             done > "{{ results_dir }}/cpu-multi-raw.txt"
+          args:
+            executable: /bin/bash
           changed_when: true
 
         - name: Calculate CPU multi-thread median
@@ -156,6 +160,8 @@
               sysbench memory --memory-oper=read --memory-total-size={{ sysbench_memory_size }} --threads={{ ansible_processor_vcpus }} run \
                 | grep "transferred" | sed -n 's/.*(\([0-9.]*\) MiB\/sec.*/\1/p' | head -1
             done > "{{ results_dir }}/mem-read-raw.txt"
+          args:
+            executable: /bin/bash
           changed_when: true
 
         - name: Calculate RAM read median
@@ -178,6 +184,8 @@
               sysbench memory --memory-oper=write --memory-total-size={{ sysbench_memory_size }} --threads={{ ansible_processor_vcpus }} run \
                 | grep "transferred" | sed -n 's/.*(\([0-9.]*\) MiB\/sec.*/\1/p' | head -1
             done > "{{ results_dir }}/mem-write-raw.txt"
+          args:
+            executable: /bin/bash
           changed_when: true
 
         - name: Calculate RAM write median
@@ -209,6 +217,8 @@
                   --group_reporting --output-format=json \
                   | jq '.jobs[0].read.iops'
             done > "{{ results_dir }}/disk-iops-raw.txt"
+          args:
+            executable: /bin/bash
           changed_when: true
           register: disk_iops_raw
           retries: 2

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -162,6 +162,14 @@ function App() {
     return filterData(data?.ranking, filters)
   }, [data?.ranking, filters])
 
+  const effectiveRanking = useMemo(() => {
+    return (filteredRanking || []).map(r => ({
+      ...r,
+      effectiveValue: filters.includeDisk ? r.cpu_value_monthly : (r.value_no_disk || r.cpu_value_monthly),
+      effectiveOverall: filters.includeDisk ? (r.overall_score || 0) : (r.overall_no_disk || 0),
+    }))
+  }, [filteredRanking, filters.includeDisk])
+
   const filteredCharts = useMemo(() => {
     if (!effectiveRanking.length) return null
 
@@ -180,14 +188,6 @@ function App() {
       value: buildChart(r => r.effectiveValue ?? r.cpu_value_monthly),
     }
   }, [effectiveRanking])
-
-  const effectiveRanking = useMemo(() => {
-    return (filteredRanking || []).map(r => ({
-      ...r,
-      effectiveValue: filters.includeDisk ? r.cpu_value_monthly : (r.value_no_disk || r.cpu_value_monthly),
-      effectiveOverall: filters.includeDisk ? (r.overall_score || 0) : (r.overall_no_disk || 0),
-    }))
-  }, [filteredRanking, filters.includeDisk])
 
   const toggleInstanceSelection = (instanceType) => {
     setSelectedForComparison(prev => {

--- a/scripts/merge_summaries.py
+++ b/scripts/merge_summaries.py
@@ -200,12 +200,11 @@ def rescale_scores(instances: list[dict]) -> list[dict]:
             if max_values[mk] > 0:
                 scores[sk] = round(val / max_values[mk] * 100, 1)
 
-        # Recalculate overall as average of component scores
-        component_scores = [scores.get(k, 0) for k in score_keys]
-        scores["overall"] = (
-            round(sum(component_scores) / len(component_scores), 1)
-            if component_scores
-            else 0
+        scores["overall"] = round(
+            ((scores.get("single_core", 0) + scores.get("multi_core", 0)) / 2) * 0.40
+            + scores.get("memory", 0) * 0.35
+            + scores.get("disk", 0) * 0.25,
+            1,
         )
 
         # overall_no_disk: average of CPU + memory (excludes disk)

--- a/tests/test_benchmark_playbook.py
+++ b/tests/test_benchmark_playbook.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Tests for benchmark playbook wiring."""
+
+import pathlib
+import unittest
+
+import yaml
+
+
+class TestBenchmarkPlaybook(unittest.TestCase):
+    def test_pipefail_shell_tasks_use_bash(self):
+        playbook_path = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "ansible"
+            / "playbooks"
+            / "benchmark.yml"
+        )
+        plays = yaml.safe_load(playbook_path.read_text())
+        tasks = plays[0]["tasks"][0]["block"]
+
+        pipefail_tasks = [
+            task
+            for task in tasks
+            if "shell" in task and "pipefail" in str(task.get("shell", ""))
+        ]
+
+        self.assertGreater(len(pipefail_tasks), 0)
+        for task in pipefail_tasks:
+            self.assertEqual(task.get("args", {}).get("executable"), "/bin/bash")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frontend_source.py
+++ b/tests/test_frontend_source.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import pathlib
+import unittest
+
+
+class TestFrontendSource(unittest.TestCase):
+    def test_effective_ranking_is_initialized_before_chart_memo(self):
+        source = pathlib.Path("frontend/src/App.jsx").read_text()
+
+        self.assertLess(
+            source.index("const effectiveRanking = useMemo"),
+            source.index("const filteredCharts = useMemo"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_summaries.py
+++ b/tests/test_merge_summaries.py
@@ -140,6 +140,39 @@ class TestRescaleScores(unittest.TestCase):
         self.assertEqual(cx11["scores"]["memory"], 50.0)
         self.assertEqual(cx11["scores"]["disk"], 50.0)
 
+    def test_rescale_uses_provider_score_weighting(self):
+        instances = [
+            {
+                "id": "cpu-heavy",
+                "metrics": {
+                    "cpu_single_events": 1000,
+                    "cpu_multi_events": 1000,
+                    "memory_mib_per_sec": 500,
+                    "disk_iops": 500,
+                },
+                "scores": {},
+                "pricing": {"monthly": 10},
+                "value": 0,
+            },
+            {
+                "id": "balanced-max",
+                "metrics": {
+                    "cpu_single_events": 1000,
+                    "cpu_multi_events": 1000,
+                    "memory_mib_per_sec": 1000,
+                    "disk_iops": 1000,
+                },
+                "scores": {},
+                "pricing": {"monthly": 10},
+                "value": 0,
+            },
+        ]
+
+        result = ms.rescale_scores(instances)
+        cpu_heavy = next(i for i in result if i["id"] == "cpu-heavy")
+
+        self.assertEqual(cpu_heavy["scores"]["overall"], 70.0)
+
     def test_rescale_empty_list(self):
         """Test rescaling an empty list."""
         result = ms.rescale_scores([])

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,10 +6,63 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 import validate  # noqa: E402
+
+
+class TestRunCommand(unittest.TestCase):
+    def test_run_command_returns_stderr_on_exception(self):
+        with mock.patch("subprocess.run", side_effect=OSError("boom")):
+            success, stdout, stderr = validate.run_command(["tool", "--version"])
+
+        self.assertFalse(success)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "boom")
+
+
+class TestValidateFrontend(unittest.TestCase):
+    def setUp(self):
+        self.original_cwd = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+
+    def test_missing_frontend_fails(self):
+        self.assertFalse(validate.validate_frontend())
+
+    def test_invalid_package_json_fails(self):
+        frontend = Path("frontend")
+        frontend.mkdir()
+        (frontend / "package.json").write_text("{invalid")
+        (frontend / "vite.config.js").write_text("")
+        (frontend / "index.html").write_text("")
+
+        self.assertFalse(validate.validate_frontend())
+
+
+class TestValidateGithubActions(unittest.TestCase):
+    def setUp(self):
+        self.original_cwd = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+
+    def test_missing_workflows_fails(self):
+        self.assertFalse(validate.validate_github_actions())
+
+    def test_invalid_workflow_yaml_fails(self):
+        workflows = Path(".github/workflows")
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: [")
+
+        self.assertFalse(validate.validate_github_actions())
 
 
 class TestValidateDocumentation(unittest.TestCase):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import pathlib
+import unittest
+
+
+class TestWorkflows(unittest.TestCase):
+    def test_benchmark_workflow_does_not_refetch_runner_ip_in_python(self):
+        workflow = pathlib.Path(".github/workflows/benchmark.yml").read_text()
+
+        self.assertNotIn("os.popen", workflow)
+        self.assertIn('new_ip = os.environ["RUNNER_IP"]', workflow)
+
+    def test_benchmark_summary_is_passed_through_env(self):
+        workflow = pathlib.Path(".github/workflows/benchmark.yml").read_text()
+
+        self.assertIn("BENCHMARK_SUMMARY:", workflow)
+        self.assertIn("process.env.BENCHMARK_SUMMARY", workflow)
+        self.assertNotIn(
+            "const summary = `${{ needs.process.outputs.summary }}`", workflow
+        )
+
+    def test_benchmark_all_destroy_failures_are_not_suppressed(self):
+        workflow = pathlib.Path(".github/workflows/benchmark-all.yml").read_text()
+
+        self.assertNotIn(
+            'allowed_ssh_ips=[\\"${{ steps.get_ip.outputs.ip }}/32\\"]" || true',
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Restore the benchmark workflow and dashboard runtime after the latest release, and align merged dashboard scoring with provider scoring.

## Related issue

None

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [ ] CI passes