### PR TITLE
feat: expand azure benchmark candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/fabianwimberger/cloud-bench/branch/main/graph/badge.svg)](https://codecov.io/gh/fabianwimberger/cloud-bench)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 31 instance types across Hetzner Cloud, AWS EC2, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP), and Microsoft Azure.
+A cloud instance benchmarking suite comparing CPU, memory, and disk performance across providers with cost analysis. 36 instance types across Hetzner Cloud, AWS EC2, OVHcloud, Oracle Cloud (OCI), Google Cloud Platform (GCP), and Microsoft Azure.
 
 ## Background
 
@@ -12,7 +12,7 @@ A €20 instance can mean very different things between providers. This runs the
 
 ## Features
 
-- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI, GCP, Azure (31 instance types)
+- **Multi-provider** — Hetzner Cloud, AWS EC2, OVHcloud, OCI, GCP, Azure (36 instance types)
 - **Standardized benchmarks** — CPU (sysbench), Memory (sysbench), Disk I/O (fio)
 - **Metric averaging** — scores based on all historical runs, not just the latest
 - **Cost analysis** — performance per dollar with EUR/USD toggle

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -298,6 +298,24 @@ providers:
       northeurope:
         name: Dublin
     instances:
+    - id: Standard_B2ls_v2
+      name: B2ls v2
+      arch: X86
+      vcpu: 2
+      ram_gb: 4
+      disk_gb: 30
+      pricing:
+        hourly: 0.0456
+        monthly: 32.83
+    - id: Standard_B2s_v2
+      name: B2s v2
+      arch: X86
+      vcpu: 2
+      ram_gb: 8
+      disk_gb: 30
+      pricing:
+        hourly: 0.0912
+        monthly: 65.66
     - id: Standard_D2as_v7
       name: D2as v7
       arch: X86
@@ -307,6 +325,24 @@ providers:
       pricing:
         hourly: 0.101
         monthly: 72.72
+    - id: Standard_D4as_v7
+      name: D4as v7
+      arch: X86
+      vcpu: 4
+      ram_gb: 16
+      disk_gb: 30
+      pricing:
+        hourly: 0.202
+        monthly: 145.44
+    - id: Standard_E2as_v7
+      name: E2as v7
+      arch: X86
+      vcpu: 2
+      ram_gb: 16
+      disk_gb: 30
+      pricing:
+        hourly: 0.133
+        monthly: 95.76
     - id: Standard_D2ps_v6
       name: D2ps v6
       arch: ARM64
@@ -316,6 +352,15 @@ providers:
       pricing:
         hourly: 0.0784
         monthly: 56.45
+    - id: Standard_D4ps_v6
+      name: D4ps v6
+      arch: ARM64
+      vcpu: 4
+      ram_gb: 16
+      disk_gb: 30
+      pricing:
+        hourly: 0.157
+        monthly: 113.04
 exchange_rates:
   eur_to_usd: 1.1761
   usd_to_eur: 0.8503

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ exchange_rates:
 | OVHcloud | EUR | DE1 (Frankfurt) | 5 (d2-4, b3-8, c3-4, c3-8, r3-16) |
 | OCI      | USD | eu-frankfurt-1 (Frankfurt) | 3 (e5-flex-1-4, std3-flex-1-4, a2-flex-2-4) |
 | GCP      | USD | europe-west3 (Frankfurt) | 5 (e2-standard-2, n2-standard-2, n2d-standard-2, t2d-standard-2, c4a-standard-2) |
-| Azure    | USD | northeurope (Dublin) | 2 (Standard_D2as_v7, Standard_D2ps_v6) |
+| Azure    | USD | northeurope (Dublin) | 7 (Standard_B2ls_v2, Standard_B2s_v2, Standard_D2as_v7, Standard_D4as_v7, Standard_E2as_v7, Standard_D2ps_v6, Standard_D4ps_v6) |
 
 ## Adding Instances
 

--- a/docs/cost-analysis.md
+++ b/docs/cost-analysis.md
@@ -11,7 +11,7 @@ A benchmark run provisions all configured instances for a single provider for ~1
 | OVHcloud | 5         | ~€0.15      |
 | OCI      | 3         | ~$0.10      |
 | GCP      | 5         | ~$0.15      |
-| Azure    | 4         | ~$0.10      |
+| Azure    | 7         | ~$0.15      |
 
 Exact cost depends on which instances are configured in `config/instances.yaml`. The cost-guard workflow estimates this before each run and blocks anything over $5 or 15 instances.
 
@@ -26,7 +26,7 @@ If cleanup fails and instances keep running, the maximum hourly cost is the sum 
 | OVHcloud | €0.2310             | €180.72              |
 | OCI      | $0.0684             | $48.51               |
 | GCP      | $0.5420             | $395.67              |
-| Azure    | $0.3136             | $228.93              |
+| Azure    | $0.8572             | $617.18              |
 
 ## Safety Nets
 


### PR DESCRIPTION
## What changed

Expanded Azure benchmark candidates with common North Europe VM sizes across burstable, x86 general-purpose, x86 memory-optimized, and ARM general-purpose families.

## Related issue

None

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [ ] CI passes