### PR TITLE
fix: guard azure benchmark quota

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -190,6 +190,61 @@ jobs:
           fi
           echo "arg=$INSTANCES_ARG" >> $GITHUB_OUTPUT
 
+      - name: Check Azure Core Quota
+        if: ${{ github.event.inputs.provider == 'azure' }}
+        env:
+          ENABLED_INSTANCES: ${{ steps.instances.outputs.arg }}
+          AZURE_MAX_REGIONAL_CORES: ${{ vars.AZURE_MAX_REGIONAL_CORES || '4' }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          selected = json.loads(os.environ["ENABLED_INSTANCES"])
+          max_cores = int(os.environ["AZURE_MAX_REGIONAL_CORES"])
+
+          instances = []
+          current = None
+          in_azure = False
+          for line in open("config/instances.yaml"):
+              if line.startswith("  azure:"):
+                  in_azure = True
+                  continue
+              if in_azure and line.startswith("  ") and not line.startswith("    "):
+                  break
+              if not in_azure:
+                  continue
+              stripped = line.strip()
+              if stripped.startswith("- id: "):
+                  current = {"id": stripped.removeprefix("- id: ").strip()}
+                  instances.append(current)
+              elif current is not None and stripped.startswith("vcpu: "):
+                  current["vcpu"] = int(stripped.removeprefix("vcpu: ").strip())
+
+          if selected is not None:
+              selected_set = {instance.lower() for instance in selected}
+              instances = [
+                  instance
+                  for instance in instances
+                  if instance["id"].lower() in selected_set
+              ]
+
+          total_cores = sum(int(instance.get("vcpu", 0)) for instance in instances)
+          if total_cores > max_cores:
+              names = ", ".join(instance["id"] for instance in instances)
+              print(
+                  "::error::Selected Azure instances need "
+                  f"{total_cores} regional cores in North Europe, "
+                  f"but AZURE_MAX_REGIONAL_CORES is {max_cores}. "
+                  "Run fewer instances or increase the Azure quota/repo variable."
+              )
+              print(f"Selected instances: {names}")
+              sys.exit(1)
+
+          print(f"Azure core quota check passed: {total_cores}/{max_cores} cores")
+          PY
+
       - name: Terraform Apply
         working-directory: terraform
         env:
@@ -703,6 +758,7 @@ jobs:
 
       - name: Terraform Destroy
         if: ${{ hashFiles('terraform/terraform.tfstate') != '' }}
+        continue-on-error: true
         working-directory: terraform
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -751,8 +807,18 @@ jobs:
           Path("runtime.auto.tfvars.json").write_text(json.dumps(tfvars))
           PY
 
-          terraform destroy -auto-approve \
-            -var-file=runtime.auto.tfvars.json
+          for attempt in 1 2 3; do
+            if terraform destroy -auto-approve -var-file=runtime.auto.tfvars.json; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "Terraform destroy failed, retrying after Azure resource release delay..."
+              sleep 180
+            fi
+          done
+
+          exit 1
 
       - name: Verify Cleanup
         if: always()

--- a/scripts/parse-instances.sh
+++ b/scripts/parse-instances.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-INSTANCES_INPUT="$1"
+INSTANCES_INPUT="$(echo "$1" | sed 's/[[:space:]]*,[[:space:]]*/,/g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
 
 if [ -z "$INSTANCES_INPUT" ]; then
     echo "Error: No instances specified" >&2

--- a/tests/test_parse_instances.py
+++ b/tests/test_parse_instances.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import unittest
+
+
+class TestParseInstances(unittest.TestCase):
+    def test_trims_spaces_around_commas(self):
+        result = subprocess.run(
+            [
+                "scripts/parse-instances.sh",
+                " Standard_B2ls_v2, Standard_B2s_v2 ,Standard_D2as_v7 ",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            json.loads(result.stdout),
+            ["Standard_B2ls_v2", "Standard_B2s_v2", "Standard_D2as_v7"],
+        )
+
+    def test_rejects_internal_spaces(self):
+        result = subprocess.run(
+            ["scripts/parse-instances.sh", "Standard_B2 ls_v2"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -46,6 +46,22 @@ class TestWorkflows(unittest.TestCase):
         self.assertIn("continue-on-error: true", workflow)
         self.assertIn("hashFiles('terraform/terraform.tfstate')", workflow)
 
+    def test_benchmark_workflow_checks_azure_core_quota_before_apply(self):
+        workflow = pathlib.Path(".github/workflows/benchmark.yml").read_text()
+
+        self.assertIn("Check Azure Core Quota", workflow)
+        self.assertIn("AZURE_MAX_REGIONAL_CORES", workflow)
+        self.assertLess(
+            workflow.index("Check Azure Core Quota"),
+            workflow.index("Terraform Apply"),
+        )
+
+    def test_benchmark_cleanup_retries_destroy(self):
+        workflow = pathlib.Path(".github/workflows/benchmark.yml").read_text()
+
+        self.assertIn("for attempt in 1 2 3", workflow)
+        self.assertIn("sleep 180", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Add an Azure core quota guard before provisioning, normalize instance-list whitespace, and retry cleanup when Azure temporarily reserves network interfaces.

## Related issue

Fixes #

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [ ] CI passes