### PR TITLE
ci: pin ruff to 0.15.22 in Python lint job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,7 @@ jobs:
       - run: |
           pip install -r scripts/requirements.txt
           pip install -r tests/requirements-test.txt
-          pip install ruff mypy types-PyYAML types-requests
+          pip install ruff==0.15.22 mypy types-PyYAML types-requests
 
       - name: Lint with ruff
         run: ruff check scripts/ tests/


### PR DESCRIPTION
ruff 0.16.0 changed its default enabled rule set, which broke the unpinned lint step in the Python CI job against existing code (no ruff config exists in this repo). Pins to the last known-good version.