### PR TITLE
fix: bump nanoid to 3.3.18 to fix high severity npm audit finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Custom generators could loop indefinitely when size is zero (GHSA-2v37-7h3g-55p8). Transitive dependency via postcss/vite, already satisfied by the existing ^3.3.16 range.