### PR TITLE
fix: convert prices at view time instead of at bench

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,17 @@ const DataAPI = {
   }
 }
 
+function convertCurrency(amount, fromCurrency, toCurrency, exchangeRates) {
+  if (!fromCurrency || fromCurrency === toCurrency || !exchangeRates) return amount
+  if (fromCurrency === 'EUR' && toCurrency === 'USD') {
+    return amount * (exchangeRates.eur_to_usd || 1)
+  }
+  if (fromCurrency === 'USD' && toCurrency === 'EUR') {
+    return amount * (exchangeRates.usd_to_eur || 1)
+  }
+  return amount
+}
+
 function parseExprFilter(expr, value) {
   if (!expr || expr.trim() === '') return true
   const match = expr.trim().match(/^([<>]=?|=)?\s*(\d+\.?\d*)$/)
@@ -57,6 +68,7 @@ function transformData(data) {
       vcpu: inst.specs?.vcpu || 0,
       ram_gb: inst.specs?.ram_gb || 0,
       disk_gb: inst.specs?.disk_gb || 0,
+      currency: inst.currency || 'USD',
       price_hourly: inst.pricing?.hourly || 0,
       price_monthly: inst.pricing?.monthly || 0,
       single_core_score: inst.scores?.single_core || 0,
@@ -140,12 +152,13 @@ function App() {
       const transformed = transformData(summary)
       setData(transformed)
 
-      setDisplayCurrency(transformed.metadata?.currency || 'USD')
-
+      const maxPriceUsd = Math.max(...transformed.ranking.map(r =>
+        convertCurrency(r.price_monthly, r.currency, 'USD', transformed.metadata?.exchange_rates)
+      ))
       setFilters(prev => ({
         ...prev,
         min_monthly_price: 0,
-        max_monthly_price: Math.ceil(Math.max(...transformed.ranking.map(r => r.price_monthly)) * 1.2)
+        max_monthly_price: Math.ceil(maxPriceUsd * 1.2)
       }))
 
       setError(null)
@@ -158,9 +171,19 @@ function App() {
     }
   }
 
+  const exchangeRates = data?.metadata?.exchange_rates
+
+  const pricedRanking = useMemo(() => {
+    return (data?.ranking || []).map(r => ({
+      ...r,
+      price_hourly: convertCurrency(r.price_hourly, r.currency, displayCurrency, exchangeRates),
+      price_monthly: convertCurrency(r.price_monthly, r.currency, displayCurrency, exchangeRates),
+    }))
+  }, [data?.ranking, displayCurrency, exchangeRates])
+
   const filteredRanking = useMemo(() => {
-    return filterData(data?.ranking, filters)
-  }, [data?.ranking, filters])
+    return filterData(pricedRanking, filters)
+  }, [pricedRanking, filters])
 
   const effectiveRanking = useMemo(() => {
     return (filteredRanking || []).map(r => ({
@@ -216,33 +239,18 @@ function App() {
     setSelectedHistoryInstance(null)
   }, [])
 
-  const nativeCurrency = data?.metadata?.currency || 'USD'
-  const exchangeRates = data?.metadata?.exchange_rates
-
-  const convertAmount = (amount) => {
-    if (displayCurrency === nativeCurrency || !exchangeRates) {
-      return amount
-    }
-    if (nativeCurrency === 'EUR' && displayCurrency === 'USD') {
-      return amount * (exchangeRates.eur_to_usd || 1)
-    }
-    if (nativeCurrency === 'USD' && displayCurrency === 'EUR') {
-      return amount * (exchangeRates.usd_to_eur || 1)
-    }
-    return amount
-  }
-
   const currencyProps = {
     displayCurrency,
-    nativeCurrency,
-    exchangeRates,
-    formatPrice: (amount) => {
-      const converted = convertAmount(amount)
+    formatPrice: (amount, fromCurrency = displayCurrency) => {
+      const converted = convertCurrency(amount, fromCurrency, displayCurrency, exchangeRates)
       const symbol = displayCurrency === 'EUR' ? '\u20AC' : '$'
       return `${symbol}${converted.toFixed(2)}`
     },
-    formatPriceRaw: (amount) => convertAmount(amount),
+    formatPriceRaw: (amount, fromCurrency = displayCurrency) =>
+      convertCurrency(amount, fromCurrency, displayCurrency, exchangeRates),
   }
+
+  const pricedData = data ? { ...data, ranking: pricedRanking } : data
 
   if (loading && !data) {
     return (
@@ -265,10 +273,10 @@ function App() {
           </div>
         )}
 
-        <StatsOverview data={data} currency={currencyProps} />
+        <StatsOverview data={pricedData} currency={currencyProps} />
 
         <InstanceFilter
-          ranking={data?.ranking}
+          ranking={pricedRanking}
           filters={filters}
           onFilterChange={setFilters}
           currency={currencyProps}

--- a/frontend/src/components/InstanceHistory.jsx
+++ b/frontend/src/components/InstanceHistory.jsx
@@ -196,6 +196,9 @@ function InstanceHistory({ instanceType, historyEntry, historyError, onClose, cu
 
   const displayCurrency = currency?.displayCurrency || 'EUR'
   const fp = currency?.formatPrice || (v => `${displayCurrency === 'EUR' ? '\u20AC' : '$'}${v.toFixed(2)}`)
+  // Each history run carries its own native currency (missing on runs
+  // recorded before this field existed, which were already stored as USD).
+  const fpRun = (amount, runCurrency) => fp(amount, runCurrency || 'USD')
 
   return (
     <div className="history-overlay" onClick={onClose}>
@@ -273,7 +276,7 @@ function InstanceHistory({ instanceType, historyEntry, historyError, onClose, cu
                     </div>
                   </td>
                   <td className="price-cell cell-numeric">
-                    {run.pricing?.monthly != null ? fp(run.pricing.monthly) : '—'}
+                    {run.pricing?.monthly != null ? fpRun(run.pricing.monthly, run.currency) : '—'}
                   </td>
                 </tr>
               ))}

--- a/scripts/build_history.py
+++ b/scripts/build_history.py
@@ -36,13 +36,12 @@ def load_detail(detail_path: str) -> dict | None:
         return None
 
 
-def extract_instance_data(
-    detail: dict, run_meta: dict, eur_to_usd: float
-) -> dict[str, dict]:
+def extract_instance_data(detail: dict, run_meta: dict) -> dict[str, dict]:
     """Extract per-instance data from a detail.json file.
 
     Returns a dict mapping instance_id -> {scores, metrics, pricing, specs}.
-    Pricing is normalized to USD.
+    Pricing is kept in its native currency; conversion happens only when the
+    frontend displays it, using the current exchange rate.
     """
     metadata = detail.get("metadata", {})
     currency = metadata.get("currency", "USD")
@@ -54,13 +53,11 @@ def extract_instance_data(
             continue
 
         pricing = dict(inst.get("pricing", {}))
-        if currency == "EUR" and eur_to_usd != 1.0:
-            pricing["hourly"] = round(pricing.get("hourly", 0) * eur_to_usd, 4)
-            pricing["monthly"] = round(pricing.get("monthly", 0) * eur_to_usd, 2)
 
         instances_data[inst_id] = {
             "timestamp": run_meta.get("timestamp", ""),
             "region": run_meta.get("region", ""),
+            "currency": currency,
             "scores": inst.get("scores", {}),
             "metrics": {
                 "cpu_single_raw": inst.get("metrics", {}).get(
@@ -113,9 +110,7 @@ def build_history(data_dir: str) -> dict:
             continue
 
         provider = run.get("provider", "unknown")
-        meta = detail.get("metadata", {})
-        eur_to_usd = meta.get("exchange_rates", {}).get("eur_to_usd", 1.0)
-        instance_data = extract_instance_data(detail, run, eur_to_usd)
+        instance_data = extract_instance_data(detail, run)
 
         for inst_id, run_data in instance_data.items():
             if inst_id not in history:

--- a/scripts/merge_summaries.py
+++ b/scripts/merge_summaries.py
@@ -101,7 +101,6 @@ def main():
             exchange_rates = latest_meta["exchange_rates"]
 
         currency = latest_meta.get("currency", "USD")
-        eur_to_usd = latest_meta.get("exchange_rates", {}).get("eur_to_usd", 1.0)
 
         run_count_for_provider = len(provider_runs)
 
@@ -122,15 +121,12 @@ def main():
                         metrics[mk] = round(sum(values) / len(values), 1)
                 print(f"  [AVG] {inst_id}: averaged {len(inst_list)} runs")
 
-            # Tag each instance with its provider for the frontend
+            # Tag each instance with its provider and native pricing currency.
+            # Pricing stays in its native currency; conversion happens only
+            # when the frontend displays it, using the current exchange rate.
             inst["provider"] = provider
             inst["region"] = provider_runs[-1].get("region", "")
-
-            # Normalize all prices to USD
-            if currency == "EUR":
-                pricing = inst.get("pricing", {})
-                pricing["hourly"] = round(pricing.get("hourly", 0) * eur_to_usd, 4)
-                pricing["monthly"] = round(pricing.get("monthly", 0) * eur_to_usd, 2)
+            inst["currency"] = currency
 
             all_instances.append(inst)
             all_labels.append(inst["id"])
@@ -140,14 +136,13 @@ def main():
         )
 
     # Re-score across all instances so scores are comparable
-    all_instances = rescale_scores(all_instances)
+    all_instances = rescale_scores(all_instances, exchange_rates)
 
     merged = {
         "schema_version": "2.0",
         "metadata": {
             "generated_at": datetime.now().isoformat(),
             "run_count": len(all_instances),
-            "currency": "USD",
             "providers": providers_seen,
             "exchange_rates": exchange_rates,
         },
@@ -166,10 +161,14 @@ def main():
     )
 
 
-def rescale_scores(instances: list[dict]) -> list[dict]:
+def rescale_scores(
+    instances: list[dict], exchange_rates: dict | None = None
+) -> list[dict]:
     """Rescale scores across all instances so they are comparable."""
     if not instances:
         return instances
+
+    eur_to_usd = (exchange_rates or {}).get("eur_to_usd", 1.0)
 
     metrics_keys = [
         "cpu_single_events",
@@ -214,8 +213,12 @@ def rescale_scores(instances: list[dict]) -> list[dict]:
             round(sum(no_disk_scores) / len(no_disk_scores), 1) if no_disk_scores else 0
         )
 
-        # Recalculate value score (overall / monthly price)
+        # Recalculate value score (overall / monthly price). Normalize to USD
+        # first so instances priced in different native currencies remain
+        # comparable; the stored native pricing itself is left untouched.
         monthly = inst.get("pricing", {}).get("monthly", 0)
+        if inst.get("currency") == "EUR":
+            monthly = monthly * eur_to_usd
         if monthly > 0:
             inst["value"] = round(scores["overall"] / monthly, 1)
             inst["value_no_disk"] = round(scores["overall_no_disk"] / monthly, 1)

--- a/tests/test_build_history.py
+++ b/tests/test_build_history.py
@@ -86,7 +86,7 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z", "region": "nbg1"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.0)
+        result = bh.extract_instance_data(detail, run_meta)
 
         self.assertIn("cx11", result)
         self.assertEqual(result["cx11"]["timestamp"], "2024-01-01T00:00:00Z")
@@ -104,7 +104,7 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z", "region": "nbg1"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.0)
+        result = bh.extract_instance_data(detail, run_meta)
 
         self.assertEqual(len(result), 2)
         self.assertIn("cx11", result)
@@ -120,7 +120,7 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z", "region": "nbg1"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.0)
+        result = bh.extract_instance_data(detail, run_meta)
 
         self.assertEqual(len(result), 1)
         self.assertIn("cx11", result)
@@ -143,7 +143,7 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.0)
+        result = bh.extract_instance_data(detail, run_meta)
 
         # Legacy names should be mapped to new names
         self.assertEqual(result["cx11"]["metrics"]["cpu_single_raw"], 1000)
@@ -156,12 +156,12 @@ class TestExtractInstanceData(unittest.TestCase):
         detail = {"instances": []}
         run_meta = {"timestamp": "2024-01-01T00:00:00Z"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.0)
+        result = bh.extract_instance_data(detail, run_meta)
 
         self.assertEqual(len(result), 0)
 
-    def test_extract_converts_eur_to_usd(self):
-        """Test that EUR pricing is converted to USD."""
+    def test_extract_keeps_eur_pricing_native(self):
+        """Test that EUR pricing is kept in its native currency."""
         detail = {
             "metadata": {"currency": "EUR"},
             "instances": [
@@ -174,10 +174,11 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z", "region": "fsn1"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.15)
+        result = bh.extract_instance_data(detail, run_meta)
 
-        self.assertAlmostEqual(result["cax11"]["pricing"]["monthly"], 5.16, places=2)
-        self.assertAlmostEqual(result["cax11"]["pricing"]["hourly"], 0.0083, places=4)
+        self.assertEqual(result["cax11"]["pricing"]["monthly"], 4.49)
+        self.assertEqual(result["cax11"]["pricing"]["hourly"], 0.0072)
+        self.assertEqual(result["cax11"]["currency"], "EUR")
 
     def test_extract_usd_pricing_unchanged(self):
         """Test that USD pricing is not converted."""
@@ -193,10 +194,11 @@ class TestExtractInstanceData(unittest.TestCase):
         }
         run_meta = {"timestamp": "2024-01-01T00:00:00Z"}
 
-        result = bh.extract_instance_data(detail, run_meta, 1.15)
+        result = bh.extract_instance_data(detail, run_meta)
 
         self.assertEqual(result["t3.micro"]["pricing"]["monthly"], 7.59)
         self.assertEqual(result["t3.micro"]["pricing"]["hourly"], 0.0104)
+        self.assertEqual(result["t3.micro"]["currency"], "USD")
 
 
 class TestBuildHistory(unittest.TestCase):

--- a/tests/test_merge_summaries.py
+++ b/tests/test_merge_summaries.py
@@ -472,8 +472,8 @@ class TestMain(unittest.TestCase):
         finally:
             sys.argv = original_argv
 
-    def test_main_eur_to_usd_conversion(self):
-        """Test that EUR prices are converted to USD."""
+    def test_main_preserves_native_currency(self):
+        """Test that pricing stays in its native currency, tagged per instance."""
         self.create_manifest(
             [
                 {
@@ -526,12 +526,41 @@ class TestMain(unittest.TestCase):
             with open(self.output_path) as f:
                 result = json.load(f)
 
-            # Prices should be converted to USD
-            pricing = result["summary"]["instances"][0]["pricing"]
-            self.assertAlmostEqual(pricing["monthly"], 3.79, places=1)  # 3.49 * 1.087
-            self.assertEqual(result["metadata"]["currency"], "USD")
+            # Pricing stays untouched in its native currency
+            instance = result["summary"]["instances"][0]
+            self.assertEqual(instance["pricing"]["monthly"], 3.49)
+            self.assertEqual(instance["pricing"]["hourly"], 0.0048)
+            self.assertEqual(instance["currency"], "EUR")
+            self.assertNotIn("currency", result["metadata"])
         finally:
             sys.argv = original_argv
+
+    def test_value_normalizes_eur_for_ranking(self):
+        """EUR-priced instances should be normalized to USD before ranking,
+        so the stored value score stays comparable to USD-priced instances,
+        while the instance's own native pricing is left untouched."""
+        instances = [
+            {
+                "id": "cx11",
+                "metrics": {
+                    "cpu_single_events": 1000,
+                    "cpu_multi_events": 2000,
+                    "memory_mib_per_sec": 8000,
+                    "disk_iops": 10000,
+                },
+                "scores": {"overall": 50},
+                "pricing": {"monthly": 10},
+                "currency": "EUR",
+                "value": 0,
+            }
+        ]
+
+        result = ms.rescale_scores(instances, {"eur_to_usd": 1.1})
+
+        # Value = overall_score / (monthly_price * eur_to_usd) = 100 / 11
+        self.assertAlmostEqual(result[0]["value"], round(100 / 11, 1))
+        # Native pricing is untouched
+        self.assertEqual(result[0]["pricing"]["monthly"], 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Displayed prices fluctuated across benchmark runs even when the underlying instance price hadn't changed, because EUR prices were converted to USD during merge/history generation using whatever exchange rate was live at that processing time. Pricing is now stored per-instance in its native currency all the way through the pipeline, and converted to the selected display currency only in the frontend, at render time, using the current exchange rate.

## Related issue

Fixes #

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes