### PR TITLE
fix: bill Hetzner runs a full hour in cost estimates

### DIFF
--- a/scripts/estimate_cost.py
+++ b/scripts/estimate_cost.py
@@ -27,13 +27,18 @@ def estimate_cost(
     # 20 minutes runtime (conservative)
     RUNTIME_HOURS = 0.33
 
+    # Providers that round any partial hour up to a full hour's charge.
+    # Everyone else bills per-second/per-minute, so the actual runtime applies.
+    HOURLY_ROUNDED_PROVIDERS = {"hetzner"}
+    billing_hours = 1.0 if provider in HOURLY_ROUNDED_PROVIDERS else RUNTIME_HOURS
+
     # Get exchange rates from config
     exchange = config.get("exchange_rates", {})
     eur_to_usd = exchange.get("eur_to_usd", 1.087)
     usd_to_eur = exchange.get("usd_to_eur", 0.92)
 
     total_cost_native = sum(
-        i.get("pricing", {}).get("hourly", 0) * RUNTIME_HOURS for i in to_benchmark
+        i.get("pricing", {}).get("hourly", 0) * billing_hours for i in to_benchmark
     )
 
     # Convert to both EUR and USD

--- a/tests/test_estimate_cost.py
+++ b/tests/test_estimate_cost.py
@@ -78,10 +78,22 @@ class TestEstimateCost(unittest.TestCase):
         self.assertIn("cpx11", result["instances"])
         self.assertIn("cax11", result["instances"])
 
-        # Cost calculation: 0.33 hours * sum of hourly rates
-        # (0.0048 + 0.0066 + 0.0048) * 0.33 = 0.0056436 EUR
+        # Hetzner rounds any partial hour up to a full hour's charge:
+        # (0.0048 + 0.0066 + 0.0048) * 1.0 = 0.0162 EUR
         self.assertGreater(result["cost_eur"], 0)
         self.assertEqual(result["cost_usd"], round(result["cost_eur"] * 1.087, 4))
+
+    def test_hetzner_bills_full_hour_even_for_short_runtime(self):
+        """Hetzner rounds any partial hour up to a full hour's charge."""
+        result = ec.estimate_cost("hetzner", "cx11", self.config_path)
+
+        self.assertEqual(result["cost_eur"], round(0.0048 * 1.0, 4))
+
+    def test_aws_bills_actual_runtime_not_full_hour(self):
+        """AWS bills per-second, so only the actual runtime applies."""
+        result = ec.estimate_cost("aws", "t3.micro", self.config_path)
+
+        self.assertEqual(result["cost_usd"], round(0.0104 * 0.33, 4))
 
     def test_estimate_specific_instances(self):
         """Test estimating cost for specific instances."""


### PR DESCRIPTION
## What changed

The cost guard estimated every provider's cost using a flat 20-minute (0.33h) runtime. Hetzner actually rounds any partial hour of usage up to a full hour's charge, so short benchmark runs were undercounted. Verified current billing docs: Hetzner still rounds up to the full hour; OVHcloud has since moved to per-second billing (no more hourly rounding), and AWS/GCP/Azure/OCI already bill per-second/per-minute - so only Hetzner's estimate changes.

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes